### PR TITLE
Issue 20: standardise handling of single frame versioned; bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Frame Range Shorthand
 Support for:
 
 * Standard: 1-10
-* Comma Delimted: 1-10,10-20
+* Comma Delimited: 1-10,10-20
 * Chunked: 1-100x5
 * Filled: 1-100y5
 * Staggered: 1-100:3 (1-100x3, 1-100x2, 1-100)
@@ -52,3 +52,18 @@ Finding Sequences on Disk
 seqs = fileseq.findSequencesOnDisk("/show/shot/renders/bty_foo/v1")
 ```
 
+Changes in versions >= 1.0.0
+============================
+
+From version 1.0.0, a FrameSet allows all the normal Set operations.  It is now an immutable and
+hashable object in its own right, as well.  This means that the order and contents are immutable
+values internally (a tuple and a frozenset, respectively), and that the FrameSet itself can be
+used as a key in a dictionary.
+
+This also means that the null FrameSet (FrameSet('')) is a valid object, and something you should
+expect to receive back from any Set operations that would result in an empty return value.  This
+brings the caveat that the FrameSet.start and FrameSet.end methods on a null FrameSet will raise an
+IndexError if called.
+
+To help avoid confusion, a FrameSet.is_null attribute has been added in 1.0.1, which you can check 
+before calling those methods.

--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -13,7 +13,7 @@ SPLIT_PATTERN = r"([-:,xy\d]*)([{0}]+)".format(''.join(PAD_MAP.keys()))
 SPLIT_RE = re.compile(SPLIT_PATTERN)
 
 # Regular expression pattern for matching file names on disk.
-DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]{1,})(?:(\.[^.]*$)|$))"
+DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]*)(?:(\.[^.]*$)|$))"
 DISK_RE = re.compile(DISK_PATTERN)
 
 # Regular expression pattern for matching frame set strings.

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -40,7 +40,11 @@ class FileSequence(object):
                 if a_frame:
                     self._dir, self._base, frames, self._ext = a_frame.groups()
                     self._frameSet = FrameSet(frames)
-                    self._pad = FileSequence.getPaddingChars(len(frames))
+                    if self._frameSet:
+                        self._pad = FileSequence.getPaddingChars(len(frames))
+                    else:
+                        self._pad = ''
+                        self._frameSet = None
                 # edge case 3; we've got a solitary file, not a sequence
                 else:
                     path, self._ext = os.path.splitext(sequence)
@@ -314,11 +318,12 @@ class FileSequence(object):
         String representation of this FileSequence.
         :return: str
         """
+        frameSet = str(self._frameSet or "")
         return "".join((
             self._dir,
             self._base,
-            str(self._frameSet or ""),
-            self._pad,
+            frameSet,
+            self._pad if frameSet else "",
             self._ext))
 
     @staticmethod

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -25,7 +25,7 @@ class FileSequence(object):
             self._frameSet = None
 
             try:
-                # the main case, we've got path.1-100#.exr
+                # the main case, padding characters in the path.1-100#.exr
                 path, frames, self._pad, self._ext = SPLIT_RE.split(sequence, 1)
                 self._dir, self._base = os.path.split(path)
                 self._frameSet = FrameSet(frames)
@@ -39,13 +39,18 @@ class FileSequence(object):
                 a_frame = DISK_RE.match(sequence)
                 if a_frame:
                     self._dir, self._base, frames, self._ext = a_frame.groups()
-                    self._frameSet = FrameSet(frames)
-                    if self._frameSet:
-                        self._pad = FileSequence.getPaddingChars(len(frames))
-                    else:
+                    # edge case 3: we've got a single versioned file, not a sequence
+                    if not self._base.endswith('.'):
+                        self._base = self._base + frames
                         self._pad = ''
-                        self._frameSet = None
-                # edge case 3; we've got a solitary file, not a sequence
+                    else:
+                        self._frameSet = FrameSet(frames)
+                        if self._frameSet:
+                            self._pad = FileSequence.getPaddingChars(len(frames))
+                        else:
+                            self._pad = ''
+                            self._frameSet = None
+                # edge case 4; we've got a solitary file, not a sequence
                 else:
                     path, self._ext = os.path.splitext(sequence)
                     self._dir, self._base = os.path.split(path)

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -39,6 +39,10 @@ class FrameSet(Set):
         only a "best guess" can be made)
         3: human-created frame ranges (ie 1-100x5) will be reduced to the
         actual internal frames (ie 1-96x5)
+        4: the "null" Frameset (FrameSet('')) is now a valid thing to create,
+        it is required by set operations, but may cause confusion as both its
+        start and end methods will raise IndexError.  The is_null
+        property has been added to allow you to guard against this.
     """
 
     __slots__ = ('_frange', '_items', '_order')
@@ -66,13 +70,8 @@ class FrameSet(Set):
 
         # if the user provides anything but a string, short-circuit the build
         if not isinstance(frange, basestring):
-            # we may already know frange, items, and contents; this will
-            # allow our own code to get back the instance before the expensive
-            # calculation of items and order
-            if frange is None:
-                return
             # if it's apparently a FrameSet already, short-circuit the build
-            elif set(dir(frange)).issuperset(self.__slots__):
+            if set(dir(frange)).issuperset(self.__slots__):
                 for attr in self.__slots__:
                     setattr(self, attr, getattr(frange, attr))
                 return
@@ -152,6 +151,14 @@ class FrameSet(Set):
         # this allows for hashing and fast equality checking
         self._items = frozenset(items)
         self._order = tuple(order)
+
+    @property
+    def is_null(self):
+        """
+        Read-only access to determine if the FrameSet is the null or empty FrameSet
+        :return: bool
+        """
+        return not (self._frange and self._items and self._order)
 
     @property
     def frange(self):

--- a/test/run.py
+++ b/test/run.py
@@ -1353,6 +1353,18 @@ class TestFileSequence(unittest.TestCase):
         seqs.setPadding("#")
         self.assertEquals(100, len(seqs))
 
+    def testNoPlaceholderNumExt(self):
+        basename = 'file'
+        exts = ('.7zip', '.mp4')
+
+        for ext in exts:
+            expected = basename + ext
+            seqs = FileSequence(expected)
+
+            self.assertEquals(ext, seqs.extension())
+            self.assertEquals(basename, seqs.basename())
+            self.assertEquals(expected, str(seqs))
+
     def testSplitXY(self):
         seqs = FileSequence("/cheech/0-9x1/chong.1-10#.exr")
         self.assertEquals("/cheech/0-9x1/chong.0001.exr", seqs.index(0))

--- a/test/run.py
+++ b/test/run.py
@@ -197,6 +197,7 @@ FRAME_SET_SHOULD_FAIL = [
     ("RangeWNegChunk", "1-20x-5"),
     ("RangeWNegFill", "1-20y-5"),
     ("RangeWNegStagger", "1-20:-5"),
+    ("ActualNone", None),
 ]
 
 class TestFrameSet(unittest.TestCase):
@@ -1375,6 +1376,20 @@ class TestFileSequence(unittest.TestCase):
         fs2 = cPickle.loads(s)
         self.assertEquals(str(fs), str(fs2))
         self.assertEquals(len(fs), len(fs2))
+
+    def testHasVersionNoFrame(self):
+        fs = FileSequence("/path/to/file_v2.exr")
+        self.assertEquals(fs.start(), 0)
+        self.assertEquals(fs.end(), 0)
+        self.assertEquals(fs.padding(), '')
+        self.assertEquals(str(fs), "/path/to/file_v2.exr")
+
+    def testHasFrameNoVersion(self):
+        fs = FileSequence("/path/to/file.2.exr")
+        self.assertEquals(fs.start(), 2)
+        self.assertEquals(fs.end(), 2)
+        self.assertEquals(fs.padding(), '@')
+        self.assertEquals(str(fs), "/path/to/file.2@.exr")
 
 class TestFindSequencesOnDisk(unittest.TestCase):
 


### PR DESCRIPTION
Tests and fixes to address versioned non-sequences (/path/to_v01.file) and versioned sequences (/path/to/_v01.1.file) and fixed the bug with FrameSet(None) being valid.

Also added an is_null guard to the FrameSet object, and expanded documentation of the issues around the Null FramSet.

Signed-off-by: Michael Morehouse <mmorehouse@wetafx.co.nz>