### PR TITLE
Fixes #22 - Handle FileSequence paths with no frame number, and extensio...

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -13,7 +13,7 @@ SPLIT_PATTERN = r"([-:,xy\d]*)([{0}]+)".format(''.join(PAD_MAP.keys()))
 SPLIT_RE = re.compile(SPLIT_PATTERN)
 
 # Regular expression pattern for matching file names on disk.
-DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]{1,})(?:(\.[^.]*$)|$))"
+DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]*)(?:(\.[^.]*$)|$))"
 DISK_RE = re.compile(DISK_PATTERN)
 
 # Regular expression pattern for matching frame set strings.

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -40,7 +40,11 @@ class FileSequence(object):
                 if a_frame:
                     self._dir, self._base, frames, self._ext = a_frame.groups()
                     self._frameSet = FrameSet(frames)
-                    self._pad = FileSequence.getPaddingChars(len(frames))
+                    if self._frameSet:
+                        self._pad = FileSequence.getPaddingChars(len(frames))
+                    else:
+                        self._pad = ''
+                        self._frameSet = None
                 # edge case 3; we've got a solitary file, not a sequence
                 else:
                     path, self._ext = os.path.splitext(sequence)
@@ -314,11 +318,12 @@ class FileSequence(object):
         String representation of this FileSequence.
         :return: str
         """
+        frameSet = str(self._frameSet or "")
         return "".join((
             self._dir,
             self._base,
-            str(self._frameSet or ""),
-            self._pad,
+            frameSet,
+            self._pad if frameSet else "",
             self._ext))
 
     @staticmethod

--- a/test/run.py
+++ b/test/run.py
@@ -1353,6 +1353,18 @@ class TestFileSequence(unittest.TestCase):
         seqs.setPadding("#")
         self.assertEquals(100, len(seqs))
 
+    def testNoPlaceholderNumExt(self):
+        basename = 'file'
+        exts = ('.7zip', '.mp4')
+
+        for ext in exts:
+            expected = basename + ext
+            seqs = FileSequence(expected)
+
+            self.assertEquals(ext, seqs.extension())
+            self.assertEquals(basename, seqs.basename())
+            self.assertEquals(expected, str(seqs))
+
     def testSplitXY(self):
         seqs = FileSequence("/cheech/0-9x1/chong.1-10#.exr")
         self.assertEquals("/cheech/0-9x1/chong.0001.exr", seqs.index(0))


### PR DESCRIPTION
Fixes #22 

Handle FileSequence paths with no frame number, and extension that contains a number (i.e. mp4)

Signed-off-by: Justin Israel <justinisrael@gmail.com>