### PR TITLE
Fixes #25 : findSequencesOnDisk() now breaks with non-sequence files mixed in same directory

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -13,7 +13,7 @@ SPLIT_PATTERN = r"([-:,xy\d]*)([{0}]+)".format(''.join(PAD_MAP.keys()))
 SPLIT_RE = re.compile(SPLIT_PATTERN)
 
 # Regular expression pattern for matching file names on disk.
-DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]+)?(?:(\.[^.]*$)|$))"
+DISK_PATTERN = r"^(.*/)?(?:$|(.+?)(-?\d+)?(?:(\.[^.]*$)|$))"
 DISK_RE = re.compile(DISK_PATTERN)
 
 # Regular expression pattern for matching frame set strings.

--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -13,7 +13,7 @@ SPLIT_PATTERN = r"([-:,xy\d]*)([{0}]+)".format(''.join(PAD_MAP.keys()))
 SPLIT_RE = re.compile(SPLIT_PATTERN)
 
 # Regular expression pattern for matching file names on disk.
-DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]*)(?:(\.[^.]*$)|$))"
+DISK_PATTERN = r"^(.*/)?(?:$|(.+?)([\-\d]+)?(?:(\.[^.]*$)|$))"
 DISK_RE = re.compile(DISK_PATTERN)
 
 # Regular expression pattern for matching frame set strings.

--- a/test/run.py
+++ b/test/run.py
@@ -1391,24 +1391,56 @@ class TestFileSequence(unittest.TestCase):
         self.assertEquals(fs.padding(), '@')
         self.assertEquals(str(fs), "/path/to/file.2@.exr")
 
+    def test_yield_sequences_in_list(self):
+        paths = [
+            '/path/to/file.5.png',
+            '/path/to/file.1.exr', 
+            '/path/to/file.2.exr',
+            '/path/to/file.3.exr', 
+            '/path/to/.cruft.file', 
+            '/path/to/.cruft', 
+            '/path/to/file2.exr', 
+            '/path/to/file2.7zip', 
+            '/path/to/file.2.7zip',
+            '/path/to/file.3.7zip',
+            '/path/to/file.4.7zip',
+            '/path/to/file.4.mp4',
+            '']
+        result = set([str(fs) for fs in FileSequence.yield_sequences_in_list(paths)])
+        expect = set([
+            '/path/to/file2.7zip',
+            '/path/to/file.1-3@.exr',
+            '/path/to/file.2-4@.7zip',
+            '/path/to/file2.exr',
+            '/path/to/file.4@.mp4',
+            '/path/to/.cruft.file',
+            '/path/to/.cruft',
+            '/path/to/file.5@.png'])
+        self.assertEquals(result, expect)
+
+
 class TestFindSequencesOnDisk(unittest.TestCase):
 
     def testFindSequencesOnDisk(self):
         seqs = findSequencesOnDisk("seq")
-        self.assertEquals(3, len(seqs))
+        self.assertEquals(8, len(seqs))
 
-        known = set([
-            "seq/bar1000-1002,1004-1006#.exr",
-            "seq/foo.1-5#.exr",
-            "seq/foo.1-5#.jpg",
-        ])
-        found = set([str(s) for s in seqs])
-        self.assertFalse(known.difference(found))
+        known = sorted([
+            'seq/bar1000.exr',
+            'seq/bar1001.exr',
+            'seq/bar1002.exr',
+            'seq/bar1004.exr',
+            'seq/bar1005.exr',
+            'seq/bar1006.exr',
+            'seq/foo.1-5#.exr',
+            'seq/foo.1-5#.jpg'])
+
+        found = sorted(set([str(s) for s in seqs]))
+        self.assertEquals(found, known)
 
     def testNegSequencesOnDisk(self):
         seqs = findSequencesOnDisk("seqneg")
         self.assertEquals(1, len(seqs))
-
 
     def testFindSequenceOnDiskNegative(self):
         seqs = findSequencesOnDisk("seqneg")
@@ -1419,7 +1451,7 @@ class TestFindSequencesOnDisk(unittest.TestCase):
         self.assertEquals("seqneg/bar.1000.exr", seqs[0].frame(1000))
 
 class TestFindSequenceOnDisk(unittest.TestCase):
-
+    
     def testFindSequenceOnDisk(self):
         tests = [
             ("seq/bar#.exr", "seq/bar1000-1002,1004-1006#.exr"),
@@ -1433,7 +1465,6 @@ class TestFindSequenceOnDisk(unittest.TestCase):
             self.assertTrue(isinstance(seq, FileSequence))
             actual = str(seq)
             self.assertEqual(actual, expected)
-
 
 class TestPaddingFunctions(unittest.TestCase):
     """

--- a/test/run.py
+++ b/test/run.py
@@ -1396,7 +1396,7 @@ class TestFileSequence(unittest.TestCase):
             '/path/to/file.5.png',
             '/path/to/file.1.exr', 
             '/path/to/file.2.exr',
-            '/path/to/file.3.exr', 
+            '/path/to/file.3.exr',
             '/path/to/.cruft.file', 
             '/path/to/.cruft', 
             '/path/to/file2.exr', 
@@ -1405,42 +1405,66 @@ class TestFileSequence(unittest.TestCase):
             '/path/to/file.3.7zip',
             '/path/to/file.4.7zip',
             '/path/to/file.4.mp4',
-            '']
-        result = set([str(fs) for fs in FileSequence.yield_sequences_in_list(paths)])
-        expect = set([
-            '/path/to/file2.7zip',
+            '', # empty path test
+            "mixed_seqs/file5.ext",
+            "mixed_seqs/file20.ext",
+            "mixed_seqs/file30.ext",
+            "mixed_seqs/no_ext",
+            "mixed_seqs/no_ext.200",
+            "mixed_seqs/no_ext.300",
+            "mixed_seqs/no_ext_10",
+            "mixed_seqs/not_a_seq.ext",
+            "mixed_seqs/seq.0001.ext",
+            "mixed_seqs/seq.0002.ext",
+            "mixed_seqs/seq.0003.ext",
+            "mixed_seqs/seq2a.1.ext",
+            "mixed_seqs/seq2a.2.ext",
+            "mixed_seqs/seq2a.3.ext",
+            "/path/to/file4-4.exr",
+            "/path/to/file4-5.exr",
+            "/path/to/file--4.exr",
+        ]
+        actual = set(str(fs) for fs in FileSequence.yield_sequences_in_list(paths))
+        expected = set([
+            '/path/to/file2@.7zip',
             '/path/to/file.1-3@.exr',
             '/path/to/file.2-4@.7zip',
-            '/path/to/file2.exr',
+            '/path/to/file2@.exr',
             '/path/to/file.4@.mp4',
             '/path/to/.cruft.file',
             '/path/to/.cruft',
-            '/path/to/file.5@.png'])
-        self.assertEquals(result, expect)
-
+            '/path/to/file.5@.png',
+            "mixed_seqs/file5,20,30@.ext",
+            "mixed_seqs/seq2a.1-3@.ext",
+            "mixed_seqs/seq.1-3#.ext",
+            "mixed_seqs/not_a_seq.ext",
+            "mixed_seqs/no_ext",
+            "mixed_seqs/no_ext_10@@",
+            "mixed_seqs/no_ext.200",
+            "mixed_seqs/no_ext.300",
+            '/path/to/file4-5,-4@@.exr',
+            '/path/to/file--4@@.exr',
+        ])
+        self.assertEquals(actual, expected)
 
 class TestFindSequencesOnDisk(unittest.TestCase):
 
     def testFindSequencesOnDisk(self):
         seqs = findSequencesOnDisk("seq")
-        self.assertEquals(8, len(seqs))
+        self.assertEquals(3, len(seqs))
 
-        known = sorted([
-            'seq/bar1000.exr',
-            'seq/bar1001.exr',
-            'seq/bar1002.exr',
-            'seq/bar1004.exr',
-            'seq/bar1005.exr',
-            'seq/bar1006.exr',
-            'seq/foo.1-5#.exr',
-            'seq/foo.1-5#.jpg'])
-
-        found = sorted(set([str(s) for s in seqs]))
-        self.assertEquals(found, known)
+        known = set([
+            "seq/bar1000-1002,1004-1006#.exr",
+            "seq/foo.1-5#.exr",
+            "seq/foo.1-5#.jpg",
+        ])
+        found = set([str(s) for s in seqs])
+        self.assertFalse(known.difference(found))
 
     def testNegSequencesOnDisk(self):
         seqs = findSequencesOnDisk("seqneg")
         self.assertEquals(1, len(seqs))
+
 
     def testFindSequenceOnDiskNegative(self):
         seqs = findSequencesOnDisk("seqneg")
@@ -1451,7 +1475,7 @@ class TestFindSequencesOnDisk(unittest.TestCase):
         self.assertEquals("seqneg/bar.1000.exr", seqs[0].frame(1000))
 
 class TestFindSequenceOnDisk(unittest.TestCase):
-    
+
     def testFindSequenceOnDisk(self):
         tests = [
             ("seq/bar#.exr", "seq/bar1000-1002,1004-1006#.exr"),
@@ -1465,6 +1489,7 @@ class TestFindSequenceOnDisk(unittest.TestCase):
             self.assertTrue(isinstance(seq, FileSequence))
             actual = str(seq)
             self.assertEqual(actual, expected)
+
 
 class TestPaddingFunctions(unittest.TestCase):
     """


### PR DESCRIPTION
Ref #25 
Creating a merge request for the fix supplied by @michaelmovies 
