### PR TITLE
Revert "Fixed warning about html template name"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'classic'
+html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This forced the template on readthedocs to use the classic template instead of the readthedocs template.

See https://github.com/sqlboy/fileseq/pull/35/files#r46685374