### PR TITLE
Strict prevention of memory errors, raising MaxSizeException for large FrameSets (refs #44)

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -5,6 +5,10 @@ constants - General constants of use to fileseq operations.
 
 import re
 
+# The max frame count of a FrameSet before a MaxSizeException
+# exception is raised
+MAX_FRAME_SIZE = 10000000
+    
 PAD_MAP = {"#": 4, "@": 1}
 
 # Regular expression for matching a file sequence string.

--- a/src/fileseq/exceptions.py
+++ b/src/fileseq/exceptions.py
@@ -9,6 +9,12 @@ class FileSeqException(ValueError):
     """
     pass
 
+class MaxSizeException(ValueError):
+    """
+	Thrown when a range exceeds allowable size.
+    """
+    pass
+
 class ParseException(FileSeqException):
     """
     Thrown after a frame range or file sequence parse error.

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -3,10 +3,15 @@
 frameset - A set-like object representing a frame range for fileseq.
 """
 
+import numbers
+
 from collections import Set, Sequence
-from fileseq.utils import xfrange, unique, pad
+
+from fileseq import constants
 from fileseq.constants import PAD_MAP, FRANGE_RE, PAD_RE
-from fileseq.exceptions import ParseException
+from fileseq.utils import xfrange, unique, pad
+from fileseq.exceptions import MaxSizeException, ParseException
+
 
 class FrameSet(Set):
     """
@@ -33,15 +38,19 @@ class FrameSet(Set):
         >>> {FrameSet('1-20'): 'good'}
 
     Caveats:
-        1. All frozenset operations return a normalized :class:`FrameSet`:
+        1. Because the internal storage of a ``FrameSet`` contains the discreet
+           values of the entire range, an exception will be thrown if the range
+           exceeds a large reasonable limit, which could lead to huge memory 
+           allocations or memory failures. See `fileseq.constants.MAX_FRAME_SIZE`.
+        2. All frozenset operations return a normalized :class:`FrameSet`:
            internal frames are in numerically increasing order.
-        2. Equality is based on the contents and order, NOT the frame range
+        3. Equality is based on the contents and order, NOT the frame range
            string (there are a finite, but potentially
            extremely large, number of strings that can represent any given range,
            only a "best guess" can be made).
-        3. Human-created frame ranges (ie 1-100x5) will be reduced to the
+        4. Human-created frame ranges (ie 1-100x5) will be reduced to the
            actual internal frames (ie 1-96x5).
-        4. The "null" :class:`Frameset` (``FrameSet('')``) is now a valid thing
+        5. The "null" :class:`Frameset` (``FrameSet('')``) is now a valid thing
            to create, it is required by set operations, but may cause confusion
            as both its start and end methods will raise IndexError.  The
            :meth:`is_null`
@@ -51,7 +60,9 @@ class FrameSet(Set):
     :param frange: the frame range as a string (ie "1-100x5")
     :rtype: None
     :raises: :class:`fileseq.exceptions.ParseException` if the frame range
-             (or a portion of it) could not be parsed
+             (or a portion of it) could not be parsed.
+             :class:`fileseq.exceptions.MaxSizeException` if the range exceeds
+             `fileseq.constants.MAX_FRAME_SIZE`
     """
 
     __slots__ = ('_frange', '_items', '_order')
@@ -70,7 +81,7 @@ class FrameSet(Set):
         return self
 
 
-    def __init__(self, frange):
+    def __init__(self, frange):        
         # if the user provides anything but a string, short-circuit the build
         if not isinstance(frange, basestring):
             # if it's apparently a FrameSet already, short-circuit the build
@@ -80,6 +91,7 @@ class FrameSet(Set):
                 return
             # if it's inherently disordered, sort and build
             elif isinstance(frange, Set):
+                self._maxSizeCheck(frange)
                 self._items = frozenset(map(int, frange))
                 self._order = tuple(sorted(self._items))
                 self._frange = FrameSet.framesToFrameRange(
@@ -87,6 +99,7 @@ class FrameSet(Set):
                 return
             # if it's ordered, find unique and build
             elif isinstance(frange, Sequence):
+                self._maxSizeCheck(frange)
                 items = set()
                 order = unique(items, map(int, frange))
                 self._order = tuple(order)
@@ -116,6 +129,8 @@ class FrameSet(Set):
         items = set()
         order = []
 
+        maxSize = constants.MAX_FRAME_SIZE 
+
         for part in self._frange.split(","):
             # this is to deal with leading / trailing commas
             if not part:
@@ -124,29 +139,33 @@ class FrameSet(Set):
             start, end, modifier, chunk = FrameSet._parse_frange_part(part)
             # handle batched frames (1-100x5)
             if modifier == 'x':
-                frames = xfrange(start, end, chunk)
+                frames = xfrange(start, end, chunk, maxSize=maxSize)
                 frames = [f for f in frames if f not in items]
+                self._maxSizeCheck(len(frames) + len(items))
                 order.extend(frames)
                 items.update(frames)
             # handle staggered frames (1-100:5)
             elif modifier == ':':
                 for stagger in xrange(chunk, 0, -1):
-                    frames = xfrange(start, end, stagger)
+                    frames = xfrange(start, end, stagger, maxSize=maxSize)
                     frames = [f for f in frames if f not in items]
+                    self._maxSizeCheck(len(frames) + len(items))
                     order.extend(frames)
                     items.update(frames)
             # handle filled frames (1-100y5)
             elif modifier == 'y':
-                not_good = frozenset(xfrange(start, end, chunk))
-                frames = xfrange(start, end, 1)
+                not_good = frozenset(xfrange(start, end, chunk, maxSize=maxSize))
+                frames = xfrange(start, end, 1, maxSize=maxSize)
                 frames = (f for f in frames if f not in not_good)
                 frames = [f for f in frames if f not in items]
+                self._maxSizeCheck(len(frames) + len(items))
                 order.extend(frames)
                 items.update(frames)
             # handle full ranges and single frames
             else:
-                frames = xfrange(start, end, 1 if start < end else -1)
+                frames = xfrange(start, end, 1 if start < end else -1, maxSize=maxSize)
                 frames = [f for f in frames if f not in items]
+                self._maxSizeCheck(len(frames) + len(items))
                 order.extend(frames)
                 items.update(frames)
 
@@ -298,18 +317,29 @@ class FrameSet(Set):
             >>> FrameSet('1-100x2').invertedFrameRange(5)
             '00002-00098x2'
 
+        If the inverted frame size exceeds `fileseq.constants.MAX_FRAME_SIZE`, 
+        a ``MaxSizeException`` will be raised.
+
         :type zfill: int
         :param zfill: the width to use to zero-pad the frame range string
         :rtype: str
+        :raises: :class:`fileseq.exceptions.MaxSizeException`
         """
         result = []
         frames = sorted(self.items)
         for idx, frame in enumerate(frames[:-1]):
             next_frame = frames[idx + 1]
             if next_frame - frame != 1:
-                result += xrange(frame + 1, next_frame)
+                r = xrange(frame + 1, next_frame)
+                # Check if the next update to the result set
+                # will exceed out max frame size. 
+                # Prevent memory overflows.
+                self._maxSizeCheck(len(r) + len(result))
+                result += r
+        
         if not result:
             return ''
+        
         return FrameSet.framesToFrameRange(
             result, zfill=zfill, sort=False, compress=False)
 
@@ -759,6 +789,30 @@ class FrameSet(Set):
         :rtype: :class:`FrameSet`
         """
         return FrameSet(str(self))
+
+    @classmethod
+    def _maxSizeCheck(cls, obj):
+        """
+        Raise a MaxSizeException if ``obj`` exceeds MAX_FRAME_SIZE
+
+        :type obj: number or collection
+        :raises: :class:`fileseq.exceptions.MaxSizeException`
+        """
+        fail = False
+        size = 0
+
+        if isinstance(obj, numbers.Number):
+            if obj > constants.MAX_FRAME_SIZE:
+                fail = True
+                size = obj
+
+        elif hasattr(obj, '__len__'):
+            size = len(obj)
+            fail = size > constants.MAX_FRAME_SIZE
+
+        if fail:
+            raise MaxSizeException('Frame size %s > %s (MAX_FRAME_SIZE)' \
+                    % (size, constants.MAX_FRAME_SIZE))
 
     @staticmethod
     def isFrameRange(frange):

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -9,9 +9,12 @@ from collections import Set, Sequence
 
 from fileseq import constants
 from fileseq.constants import PAD_MAP, FRANGE_RE, PAD_RE
-from fileseq.utils import xfrange, unique, pad
 from fileseq.exceptions import MaxSizeException, ParseException
+from fileseq.utils import xfrange, unique, pad
 
+# Issue #44
+# Possibly use an alternate xrange implementation, depending on platform. 
+from fileseq.utils import xrange
 
 class FrameSet(Set):
     """

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -6,7 +6,9 @@ utils - General tools of use to fileseq operations.
 import os
 from itertools import chain
 
-def xfrange(start, stop, step=1):
+from fileseq import exceptions 
+
+def xfrange(start, stop, step=1, maxSize=-1):
     """
     Returns a generator that yields the frames from start to stop, inclusive.
     In other words it adds or subtracts a frame, as necessary, to return the
@@ -16,6 +18,9 @@ def xfrange(start, stop, step=1):
     :type stop: int
     :type step: int
     :param step: Note that the sign will be ignored
+    :type maxSize: int
+    :param maxSize: If >= raise a :class:`fileseq.exceptions.MaxSizeException` 
+                    if size is exceeded
     :rtype: generator
     """
     if start <= stop:
@@ -24,7 +29,14 @@ def xfrange(start, stop, step=1):
         stop, step = stop - 1, -abs(step)
     # because an xrange is an odd object all its own, we wrap it in a
     # generator expression to get a proper Generator
-    return (f for f in xrange(start, stop, step))
+    rng = xrange(start, stop, step)
+    if maxSize >= 0:
+        size = len(rng)
+        if size > maxSize:
+            raise exceptions.MaxSizeException(
+                "Size %d > %s (MAX_FRAME_SIZE)" % (size, maxSize))
+
+    return (f for f in rng)
 
 def unique(seen, *iterables):
     """

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -4,9 +4,56 @@ utils - General tools of use to fileseq operations.
 """
 
 import os
-from itertools import chain
+from itertools import chain, count, islice
 
 from fileseq import exceptions 
+
+
+def lenRange(start, stop, step=1):
+    """
+    Get the length of values for a given range
+    """
+    return (stop - start + step - 1 + 2 * (step < 0)) // step
+
+
+class xrange2(object):
+    """
+    An itertools-based replacement for xrange which does
+    not exhibit the OverflowError issue on some platforms, 
+    when a value exceeds a C long size.
+    
+    Provides the features of an islice, with the added support
+    for checking the length of the range.
+    """
+    
+    __slots__ = ['_len', '_islice']
+    
+    def __init__(self, start, stop=None, step=1):
+        if stop is None:
+            start, stop = 0, start
+
+        self._len = lenRange(start, stop, step)
+        self._islice = islice(count(start, step), self._len)
+    
+    def __len__(self):
+        return self._len 
+    
+    def next(self):
+        return self._islice.next()
+    
+    def __iter__(self):
+        return self._islice.__iter__()
+    
+
+# Issue #44
+# On Windows platform, it is possible for xrange to get an
+# OverflowError if a value passed to xrange exceeds the size of a C long. 
+# Switch to an alternate implementation.
+if os.name == 'nt':
+    xrange = xrange2
+else:
+    xrange = xrange
+
 
 def xfrange(start, stop, step=1, maxSize=-1):
     """
@@ -27,16 +74,16 @@ def xfrange(start, stop, step=1, maxSize=-1):
         stop, step = stop + 1, abs(step)
     else:
         stop, step = stop - 1, -abs(step)
-    # because an xrange is an odd object all its own, we wrap it in a
-    # generator expression to get a proper Generator
-    rng = xrange(start, stop, step)
+        
     if maxSize >= 0:
-        size = len(rng)
+        size = lenRange(start, stop, step)
         if size > maxSize:
             raise exceptions.MaxSizeException(
                 "Size %d > %s (MAX_FRAME_SIZE)" % (size, maxSize))
-
-    return (f for f in rng)
+        
+    # because an xrange is an odd object all its own, we wrap it in a
+    # generator expression to get a proper Generator
+    return (f for f in xrange(start, stop, step))
 
 def unique(seen, *iterables):
     """

--- a/test/run.py
+++ b/test/run.py
@@ -1128,7 +1128,7 @@ class TestFrameSet(unittest.TestCase):
     def testMaxFrameSize(self):
         _maxSize = constants.MAX_FRAME_SIZE
         try:
-            maxSize = constants.MAX_FRAME_SIZE = 10000
+            maxSize = constants.MAX_FRAME_SIZE = 500
 
             # Within range
             utils.xfrange(1, 100, 1, maxSize=-1)
@@ -1432,10 +1432,18 @@ class TestFileSequence(TestBase):
         self.assertEquals("broke.0000-0002,0004,0006-0008#.exr", seq.format())
         seq = findSequencesOnDisk("step_seq")[0]
         self.assertEquals("step_seq/step1.1-13x4,14-17#.exr", str(seq))
+    
+    def testFormatInverted(self):
+        _maxSize = constants.MAX_FRAME_SIZE
+        try:
+            maxSize = constants.MAX_FRAME_SIZE = 500
 
-        # Test catching error for large inverted range
-        seq = FileSequence("/path/to/file.1,%d#.ext" % (constants.MAX_FRAME_SIZE+3))
-        self.assertRaises(exceptions.MaxSizeException, seq.format, '{inverted}')
+            # Test catching error for large inverted range
+            seq = FileSequence("/path/to/file.1,%d#.ext" % (constants.MAX_FRAME_SIZE+3))
+            self.assertRaises(exceptions.MaxSizeException, seq.format, '{inverted}')
+
+        finally:
+            constants.MAX_FRAME_SIZE = _maxSize
 
     def testSplit(self):
         seqs = FileSequence("/cheech/chong.1-10,30,40#.exr").split()

--- a/test/run.py
+++ b/test/run.py
@@ -237,6 +237,14 @@ FRAME_SET_SHOULD_FAIL = [
     ("ActualNone", None),
 ]
 
+class TestUtils(unittest.TestCase):
+    
+    def testXrange(self):
+        # Test that a platform-specific xrange does not produce OverflowError
+        xrng = utils.xrange(1, sys.maxint)
+        self.assertTrue(len(xrng) != 0)
+    
+    
 class TestFrameSet(unittest.TestCase):
     """
     Exercise the TestFrame object.  Due to the sheer number of permutations, we'll add most tests dynamically.


### PR DESCRIPTION
*For discussion only. Not ready for merge*

In response to #44, this is a very strict approach to trying to prevent cases where extremely large `FrameSet` values lead to enough heavy memory consumption or failure to allocate memory. It may be that this approach is too strict, but that is up for discussion.

A `MaxSizeException` has been created, and documented in a number of places to be raised if a `FrameSet` is going to be created with a size larger than `constants.MAX_FRAME_SIZE`. The reasoning is that a value of something like "10000000", which equate to over 4 days of frame time, is more than adequate for representing frame ranges, and anything beyond this range might be a bug or an intentional representation of a frame range. It is also meant to deal with the flaw in the fileseq implementation where `FrameSet` range sizes dictate memory consumption, because they store a number of copies of discrete values for the entire frame range. 

This branch introduces checks into a few different places such as:
* `FrameSet` constructor, when it will produce a size larger than allowed
* Inverting a range, where the new inverted range will be very large
* Optimising the `FileSequence.format()` method to not perform a potentially expensive or error raising frame range inversion when the caller isn't asking to format the inverted range.

Is this approach too aggressive? 