### PR TITLE
Restrict the start chars SPLIT_PATTERN can match

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -16,7 +16,7 @@ PAD_MAP = {"#": 4, "@": 1}
 # Example: /film/shot/renders/bilbo_bty.1-100@.exr
 # Example: /film/shot/renders/bilbo_bty.1-100@@@@#.exr
 # Example: /film/shot/renders/bilbo_bty.1-100%04d.exr
-SPLIT_PATTERN = r"([-:,xy\d]*)([{0}]+|%\d+d)".format(''.join(PAD_MAP.keys()))
+SPLIT_PATTERN = r"((?:[-\d][-:,xy\d]*)?)([{0}]+|%\d+d)".format(''.join(PAD_MAP.keys()))
 SPLIT_RE = re.compile(SPLIT_PATTERN)
 
 # Regular expression pattern for matching padding against a printf syntax

--- a/test/run.py
+++ b/test/run.py
@@ -1618,6 +1618,15 @@ class TestFileSequence(TestBase):
         ])
         self.assertEquals(actual, expected)
 
+    def testIgnoreFrameSetStrings(self):
+        for char in "xy:,".split():
+            fs = FileSequence("/path/to/file{0}1-1x1#.exr".format(char))
+            self.assertEquals(fs.basename(), "file{0}".format(char))
+            self.assertEquals(fs.start(), 1)
+            self.assertEquals(fs.end(), 1)
+            self.assertEquals(fs.padding(), '#')
+            self.assertEquals(str(fs), "/path/to/file{0}1-1x1#.exr".format(char))
+
 class TestFindSequencesOnDisk(TestBase):
 
     def testFindSequencesOnDisk(self):


### PR DESCRIPTION
SPLIT_PATTERN has no preference for the order which it matches against characters when looking for frames. This can lead it to incorrectly matching against non-frame characters when the frames aren't encased in separators. This leads to unexpected behavior

For example

```python
from fileseq import FileSequence
FileSequence("light1-1#.exr") # Succeeds
FileSequence("heavy1-1#.exr") # Fails with exception ParseException
FileSequence("heavy.1-1#.exr") # Succeeds
``` 

This patch restricts what SPLIT_PATTERN can start matching on (it has to be a number or negative number) to avoid incorrect matches on colon, comma and especially x and y