### PR TITLE
Update DISK_PATTERN to capture empty values for dir and ext

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -25,7 +25,7 @@ PRINTF_SYNTAX_PADDING_PATTERN = r"%(\d+)d"
 PRINTF_SYNTAX_PADDING_RE = re.compile(PRINTF_SYNTAX_PADDING_PATTERN)
 
 # Regular expression pattern for matching file names on disk.
-DISK_PATTERN = r"^(.*[/\\])?(?:$|(.*?)(-?\d+)?(?:(\.[^.]*$)|$))"
+DISK_PATTERN = r"^((?:.*[/\\])?)(?:(.*?)(-?\d+)?((?:\.[^.]*)?))?$"
 DISK_RE = re.compile(DISK_PATTERN)
 
 # Regular expression pattern for matching frame set strings.

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -65,8 +65,6 @@ class FileSequence(object):
             sep = utils._getPathSep(sequence)
             if not self._dir.endswith(sep):
                 self._dir += sep
-        else:
-            self._dir = ''
 
         self._zfill = self.__class__.getPaddingNum(self._pad)
 

--- a/test/run.py
+++ b/test/run.py
@@ -1531,6 +1531,7 @@ class TestFileSequence(TestBase):
         self.assertEquals(fs.start(), 0)
         self.assertEquals(fs.end(), 0)
         self.assertEquals(fs.padding(), '')
+        self.assertEquals(fs.extension(), '.exr')
         self.assertEquals(str(fs), "/path/to/file_v2.exr")
 
     def testHasFrameNoVersion(self):
@@ -1538,7 +1539,27 @@ class TestFileSequence(TestBase):
         self.assertEquals(fs.start(), 2)
         self.assertEquals(fs.end(), 2)
         self.assertEquals(fs.padding(), '@')
+        self.assertEquals(fs.extension(), '.exr')
         self.assertEquals(str(fs), "/path/to/file.2@.exr")
+
+    def testNoFrameNoVersionNoExt(self):
+        fs = FileSequence("/path/to/file")
+        self.assertEquals(fs.start(), 0)
+        self.assertEquals(fs.end(), 0)
+        self.assertEquals(fs.padding(), '')
+        self.assertEquals(fs.dirname(), '/path/to/')
+        self.assertEquals(fs.basename(), 'file')
+        self.assertEquals(fs.extension(), '')
+        self.assertEquals(str(fs), "/path/to/file")
+
+        fs = FileSequence("file")
+        self.assertEquals(fs.start(), 0)
+        self.assertEquals(fs.end(), 0)
+        self.assertEquals(fs.padding(), '')
+        self.assertEquals(fs.dirname(), '')
+        self.assertEquals(fs.basename(), 'file')
+        self.assertEquals(fs.extension(), '')
+        self.assertEquals(str(fs), "file")
 
     def testEmptyBasename(self):
         seq = FileSequence("/path/to/1-5#.exr")


### PR DESCRIPTION
DISK_PATTERN captures None values for dir and ext in edge case 2. Iterating the resulting FileSequence object, or using str() on it, then results in a TypeError exception:

```python
from fileseq import FileSequence
fs = FileSequence("/path/to/file")
str(fs) # TypeError sequence item 4: expected string, NoneType found
list(fs) # TypeError sequence item 4: expected string, NoneType found
```

This patch captures empty strings for both dir and ext so the behaviour is more consistent with the main case:

```python
from fileseq import FileSequence
fs = FileSequence("/path/to/file")
str(fs) # "/path/to/file"
list(fs) # ['/path/to/file']
```