### PR TITLE
Allow negative chunks on inverted ranges

### DIFF
--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -30,7 +30,7 @@ DISK_RE = re.compile(DISK_PATTERN)
 
 # Regular expression pattern for matching frame set strings.
 # Examples: '1' or '1-100', '1-100x5', '1-100:5', '1-100y5', '1,2', etc.
-FRANGE_PATTERN = r"^(-?\d+)(?:-(-?\d+)(?:([:xy]{1})(\d+))?)?$"
+FRANGE_PATTERN = r"^(-?\d+)(?:-(-?\d+)(?:([:xy]{1})(-?\d+))?)?$"
 FRANGE_RE = re.compile(FRANGE_PATTERN)
 
 # Regular expression for padding a frame range.

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -896,6 +896,11 @@ class FrameSet(Set):
         start, end, modifier, chunk = match.groups()
         start = int(start)
         end = int(end) if end is not None else start
+
+        if end > start and chunk is not None and int(chunk) < 0:
+            msg = 'Could not parse "{0}: chunk can not be negative'
+            raise ParseException(msg.format(frange))
+
         chunk = abs(int(chunk)) if chunk is not None else 1
         # a zero chunk is just plain illogical
         if chunk == 0:

--- a/test/test_fuzz.py
+++ b/test/test_fuzz.py
@@ -113,6 +113,7 @@ LO_RANGES = [
     ('NegToPosChunkInv', '-20-1x5', list(xrange(-20,2,5))),
     ('NegToNegChunkInv', '-20--1x5', list(xrange(-20,0,5))),
     ('PosToNegChunkInv', '20--1x5', list(xrange(20,-2,-5))),
+    ('PosToPosNegChunkInv', '20-1x-1', list(xrange(20,0,-1))),
     ('PosToPosFill', '1-20y5', list(_yrange(1,21,5))),
     ('NegToPosFill', '-1-20y5', list(_yrange(-1,21,5))),
     ('NegToNegFill', '-1--20y5', list(_yrange(-1,-21,-5))),


### PR DESCRIPTION
This is to allow the case where you receive a inverted range with a negative chuck supplied such as`5-1x-1`.  It will allow fileseq to match the semantics of `range(5,0,-1)` which produces list of integers `[5,4,3,2,1]`. Given that the code performs an `abs` on the chunk it seems like this behavior was originally intended for fileseq.

This change will still reject sequences like `1-10x-1` and allow sequences like `10-1x1`