### PR TITLE
Change docstring to Google format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ execfile(os.path.join(_ROOT, "fileseq/__version__.py"))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/src/fileseq/exceptions.py
+++ b/src/fileseq/exceptions.py
@@ -3,17 +3,20 @@
 exceptions - Exception subclasses relevant to fileseq operations.
 """
 
+
 class FileSeqException(ValueError):
     """
     Thrown for general exceptions handled by FileSeq.
     """
     pass
 
+
 class MaxSizeException(ValueError):
     """
 	Thrown when a range exceeds allowable size.
     """
     pass
+
 
 class ParseException(FileSeqException):
     """

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -16,9 +16,6 @@ from fileseq import utils
 
 class FileSequence(object):
     """:class:`FileSequence` represents an ordered sequence of files.
-    """
-    def __init__(self, sequence):
-        """Init the class
 
         Args:
             sequence (str): (ie: dir/path.1-100#.ext)
@@ -28,7 +25,10 @@ class FileSequence(object):
 
         Raises:
             :class:`fileseq.exceptions.MaxSizeException`: If frame size exceeds
-            :obj:`fileseq.constants.MAX_FRAME_SIZE`
+            :const:`fileseq.constants.MAX_FRAME_SIZE`
+    """
+    def __init__(self, sequence):
+        """Init the class
         """
         sequence = utils.asString(sequence)
 
@@ -105,7 +105,7 @@ class FileSequence(object):
             * dirname - the directory name.
 
         If asking for the inverted range value, and the new inverted range
-        exceeded :obj:`fileseq.constants.MAX_FRAME_SIZE`, a ``MaxSizeException``
+        exceeded :const:`fileseq.constants.MAX_FRAME_SIZE`, a ``MaxSizeException``
         will be raised.
 
         Args:
@@ -116,7 +116,7 @@ class FileSequence(object):
 
         Raises:
             :class:`fileseq.exceptions.MaxSizeException`: If frame size exceeds
-            :obj:`fileseq.constants.MAX_FRAME_SIZE`
+            :const:`fileseq.constants.MAX_FRAME_SIZE`
         """
         # Potentially expensive if inverted range is large
         # and user never asked for it in template
@@ -223,7 +223,7 @@ class FileSequence(object):
 
         Args:
             frameSet (:class:`fileseq.frameset.FrameSet`): the new
-            :class:`fileseq.frameset.FrameSet` object
+                :class:`fileseq.frameset.FrameSet` object
         """
         self._frameSet = frameSet
 
@@ -244,10 +244,7 @@ class FileSequence(object):
             A leading period will be added if none is provided.
 
         Args:
-            ext (str):
-
-        Returns:
-            None:
+            ext (str): the new file extension
         """
         if ext[0] != ".":
             ext = "." + ext
@@ -282,7 +279,7 @@ class FileSequence(object):
         Set a new frame range for the sequence.
 
         Args:
-            frange: a properly formatted frame range, as per
+            frange (str): a properly formatted frame range, as per
                 :class:`fileseq.frameset.FrameSet`
         """
         self._frameSet = FrameSet(frange)
@@ -297,7 +294,7 @@ class FileSequence(object):
 
         Raises:
             :class:`fileseq.exceptions.MaxSizeException`: If new inverted range
-                exceeded :obj:`fileseq.constants.MAX_FRAME_SIZE`
+                exceeded :const:`fileseq.constants.MAX_FRAME_SIZE`
         """
         if not self._frameSet:
             return ''
@@ -400,7 +397,7 @@ class FileSequence(object):
 
     def __getitem__(self, idx):
         """
-        Allows indexing and slicing into the underlying :class:`fileseq.FrameSet`.
+        Allows indexing and slicing into the underlying :class:`fileseq.frameset.FrameSet`
 
         When indexing, a string filepath is returns for the frame.
 
@@ -532,19 +529,19 @@ class FileSequence(object):
         Yield the sequences found in the given directory.
 
         Examples:
-            findSequencesOnDisk('/path/to/files')
+            >>> findSequencesOnDisk('/path/to/files')
 
-        The pattern can also specify glob-like shell wildcards including the following:
-            ?         - 1 wildcard character
-            *         - 1 or more wildcard character
-            {foo,bar} - either 'foo' or 'bar'
+        The `pattern` can also specify glob-like shell wildcards including the following:
+            * ``?``         - 1 wildcard character
+            * ``*``         - 1 or more wildcard character
+            * ``{foo,bar}`` - either 'foo' or 'bar'
 
         Exact frame ranges are not considered, and padding characters are converted to
-        wildcards (# or @)
+        wildcards (``#`` or ``@``)
 
         Examples:
-            findSequencesOnDisk('/path/to/files/image_stereo_{left,right}.#.jpg')
-            findSequencesOnDisk('/path/to/files/imag?_*_{left,right}.@@@.jpg', strictPadding=True)
+            >>> findSequencesOnDisk('/path/to/files/image_stereo_{left,right}.#.jpg')
+            >>> findSequencesOnDisk('/path/to/files/imag?_*_{left,right}.@@@.jpg', strictPadding=True)
 
         Args:
             pattern (str): directory to scan, or pattern to filter in directory
@@ -632,8 +629,8 @@ class FileSequence(object):
         """
         Search for a specific sequence on disk.
 
-        The padding characters used in the pattern are used to filter the
-        frame values of the files on disk (if strictPadding is True).
+        The padding characters used in the `pattern` are used to filter the
+        frame values of the files on disk (if `strictPadding` is True).
 
         Examples:
             Find sequence matching basename and extension, and a wildcard for
@@ -649,7 +646,7 @@ class FileSequence(object):
 
         Args:
             pattern (str): the sequence pattern being searched for
-            strictPadding (bool): if True, ignore files with padding length different from pattern
+            strictPadding (bool): if True, ignore files with padding length different from `pattern`
 
         Returns:
             str:

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -81,7 +81,7 @@ class FileSequence(object):
         Create a deep copy of this sequence
 
         Returns:
-            :obj:`fileseq.FileSequence`:
+            :obj:`.FileSequence`:
         """
         fs = self.__class__.__new__(self.__class__)
         fs.__dict__ = self.__dict__.copy()
@@ -209,21 +209,20 @@ class FileSequence(object):
 
     def frameSet(self):
         """
-        Return the :class:`fileseq.frameset.FrameSet` of the sequence if specified,
+        Return the :class:`.FrameSet` of the sequence if specified,
         otherwise None.
 
         Returns:
-            :class:`fileseq.frameset.FrameSet` or None:
+            :class:`.FrameSet` or None:
         """
         return self._frameSet
 
     def setFrameSet(self, frameSet):
         """
-        Set a new :class:`fileseq.frameset.FrameSet` for the sequence.
+        Set a new :class:`.FrameSet` for the sequence.
 
         Args:
-            frameSet (:class:`fileseq.frameset.FrameSet`): the new
-                :class:`fileseq.frameset.FrameSet` object
+            frameSet (:class:`.FrameSet`): the new :class:`.FrameSet` object
         """
         self._frameSet = frameSet
 
@@ -279,8 +278,7 @@ class FileSequence(object):
         Set a new frame range for the sequence.
 
         Args:
-            frange (str): a properly formatted frame range, as per
-                :class:`fileseq.frameset.FrameSet`
+            frange (str): a properly formatted frame range, as per :class:`.FrameSet`
         """
         self._frameSet = FrameSet(frange)
 
@@ -302,7 +300,7 @@ class FileSequence(object):
 
     def start(self):
         """
-        Returns the start frame of the sequence's :class:`fileseq.frameset.FrameSet`.
+        Returns the start frame of the sequence's :class:`.FrameSet`.
         Will return 0 if the sequence has no frame pattern.
 
         Returns:
@@ -314,7 +312,7 @@ class FileSequence(object):
 
     def end(self):
         """
-        Returns the end frame of the sequences :class:`fileseq.frameset.FrameSet`.
+        Returns the end frame of the sequences :class:`.FrameSet`.
         Will return 0 if the sequence has no frame pattern.
 
         Returns:
@@ -397,7 +395,7 @@ class FileSequence(object):
 
     def __getitem__(self, idx):
         """
-        Allows indexing and slicing into the underlying :class:`fileseq.frameset.FrameSet`
+        Allows indexing and slicing into the underlying :class:`.FrameSet`
 
         When indexing, a string filepath is returns for the frame.
 
@@ -652,7 +650,7 @@ class FileSequence(object):
             str:
 
         Raises:
-            :class:`fileseq.exceptions.FileSeqException`: if no sequence is found on disk
+            :class:`.FileSeqException`: if no sequence is found on disk
         """
         seq = cls(pattern)
 

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -13,18 +13,23 @@ from fileseq.constants import PAD_MAP, DISK_RE, SPLIT_RE, PRINTF_SYNTAX_PADDING_
 from fileseq.frameset import FrameSet
 from fileseq import utils
 
+
 class FileSequence(object):
     """:class:`FileSequence` represents an ordered sequence of files.
-    
-    If the frame size exceeds :obj:`fileseq.constants.MAX_FRAME_SIZE`, 
-    a ``MaxSizeException`` will be thrown.
-
-    :type sequence: str
-    :param sequence: (ie: dir/path.1-100#.ext)
-    :raises: :class:`fileseq.exceptions.MaxSizeException`
     """
     def __init__(self, sequence):
+        """Init the class
 
+        Args:
+            sequence (str): (ie: dir/path.1-100#.ext)
+
+        Returns:
+            :class:`FileSequence`:
+
+        Raises:
+            :class:`fileseq.exceptions.MaxSizeException`: If frame size exceeds
+            :obj:`fileseq.constants.MAX_FRAME_SIZE`
+        """
         sequence = utils.asString(sequence)
 
         if not hasattr(self, '_frameSet'):
@@ -75,7 +80,8 @@ class FileSequence(object):
         """
         Create a deep copy of this sequence
 
-        :return: :obj:`fileseq.FileSequence`
+        Returns:
+            :obj:`fileseq.FileSequence`:
         """
         fs = self.__class__.__new__(self.__class__)
         fs.__dict__ = self.__dict__.copy()
@@ -97,14 +103,20 @@ class FileSequence(object):
             * padding - the detecting amount of padding.
             * inverted - the inverted frame range. (returns "" if none)
             * dirname - the directory name.
-        
+
         If asking for the inverted range value, and the new inverted range
         exceeded :obj:`fileseq.constants.MAX_FRAME_SIZE`, a ``MaxSizeException``
         will be raised.
 
-        :type template: str
-        :rtype: str
-        :raises: :class:`fileseq.exceptions.MaxSizeException` 
+        Args:
+            template (str):
+
+        Returns:
+            str:
+
+        Raises:
+            :class:`fileseq.exceptions.MaxSizeException`: If frame size exceeds
+            :obj:`fileseq.constants.MAX_FRAME_SIZE`
         """
         # Potentially expensive if inverted range is large
         # and user never asked for it in template
@@ -124,7 +136,8 @@ class FileSequence(object):
         Split the :class:`FileSequence` into contiguous pieces and return them
         as a list of :class:`FileSequence` instances.
 
-        :rtype: list
+        Returns:
+            list[:class:`FileSequence`]:
         """
         result = []
         for frange in self.frameRange().split(","):
@@ -136,7 +149,8 @@ class FileSequence(object):
         """
         Return the directory name of the sequence.
 
-        :rtype: str
+        Returns:
+            str:
         """
         return self._dir
 
@@ -144,9 +158,8 @@ class FileSequence(object):
         """
         Set a new directory name for the sequence.
 
-        :type dirname: str
-        :param dirname: the new directory name
-        :rtype: None
+        Args:
+            dirname (str): the new directory name
         """
         # Make sure the dirname always ends in
         # a path separator character
@@ -160,7 +173,8 @@ class FileSequence(object):
         """
         Return the basename of the sequence.
 
-        :rtype: str
+        Returns:
+            str: sequence basename
         """
         return self._base
 
@@ -168,9 +182,8 @@ class FileSequence(object):
         """
         Set a new basename for the sequence.
 
-        :type base: str
-        :param base: the new base name
-        :rtype: None
+        Args:
+            base (str): the new base name
         """
         self._base = utils.asString(base)
 
@@ -178,7 +191,8 @@ class FileSequence(object):
         """
         Return the the padding characters in the sequence.
 
-        :rtype: str
+        Returns:
+            str: sequence padding
         """
         return self._pad
 
@@ -187,8 +201,8 @@ class FileSequence(object):
         Set new padding characters for the sequence.
         i.e. "#" or "@@@" or '%04d', or an empty string to disable range formatting.
 
-        :type padding: str
-        :rtype: None
+        Args:
+            padding (str): sequence padding to set
         """
         self._pad = padding
         self._zfill = self.__class__.getPaddingNum(self._pad)
@@ -198,7 +212,8 @@ class FileSequence(object):
         Return the :class:`fileseq.frameset.FrameSet` of the sequence if specified,
         otherwise None.
 
-        :rtype: :class:`fileseq.frameset.FrameSet` or None
+        Returns:
+            :class:`fileseq.frameset.FrameSet` or None:
         """
         return self._frameSet
 
@@ -206,8 +221,9 @@ class FileSequence(object):
         """
         Set a new :class:`fileseq.frameset.FrameSet` for the sequence.
 
-        :param frameSet: the new :class:`fileseq.frameset.FrameSet` object
-        :rtype: None
+        Args:
+            frameSet (:class:`fileseq.frameset.FrameSet`): the new
+            :class:`fileseq.frameset.FrameSet` object
         """
         self._frameSet = frameSet
 
@@ -215,7 +231,8 @@ class FileSequence(object):
         """
         Return the file extension of the sequence, including leading period.
 
-        :rtype: str
+        Returns:
+            str:
         """
         return self._ext
 
@@ -223,11 +240,14 @@ class FileSequence(object):
         """
         Set a new file extension for the sequence.
 
-        .. note::
+        Note:
             A leading period will be added if none is provided.
 
-        :param ext: the new file extension
-        :rtype: None
+        Args:
+            ext (str):
+
+        Returns:
+            None:
         """
         if ext[0] != ".":
             ext = "." + ext
@@ -236,6 +256,9 @@ class FileSequence(object):
     def setExtention(self, ext):
         """
         Deprecated: use :meth:`setExtension`.
+
+        Args:
+            ext (str):
         """
         import warnings
         msg = "the setExtention method is deprecated, please use setExtension"
@@ -247,7 +270,8 @@ class FileSequence(object):
         Returns the string formatted frame range of the sequence.
         Will return an empty string if the sequence has no frame pattern.
 
-        :rtype: str
+        Returns:
+            str:
         """
         if not self._frameSet:
             return ''
@@ -257,8 +281,9 @@ class FileSequence(object):
         """
         Set a new frame range for the sequence.
 
-        :param frange: a properly formatted frame range, as per :class:`fileseq.frameset.FrameSet`
-        :rtype: None
+        Args:
+            frange: a properly formatted frame range, as per
+                :class:`fileseq.frameset.FrameSet`
         """
         self._frameSet = FrameSet(frange)
 
@@ -267,11 +292,12 @@ class FileSequence(object):
         Returns the inverse string formatted frame range of the sequence.
         Will return an empty string if the sequence has no frame pattern.
 
-        If new inverted range exceeded :obj:`fileseq.constants.MAX_FRAME_SIZE`, 
-        a ``MaxSizeException`` will be raised.
+        Returns:
+            str:
 
-        :rtype: str
-        :raises: :class:`fileseq.exceptions.MaxSizeException`
+        Raises:
+            :class:`fileseq.exceptions.MaxSizeException`: If new inverted range
+                exceeded :obj:`fileseq.constants.MAX_FRAME_SIZE`
         """
         if not self._frameSet:
             return ''
@@ -282,7 +308,8 @@ class FileSequence(object):
         Returns the start frame of the sequence's :class:`fileseq.frameset.FrameSet`.
         Will return 0 if the sequence has no frame pattern.
 
-        :rtype: int
+        Returns:
+            int:
         """
         if not self._frameSet:
             return 0
@@ -293,7 +320,8 @@ class FileSequence(object):
         Returns the end frame of the sequences :class:`fileseq.frameset.FrameSet`.
         Will return 0 if the sequence has no frame pattern.
 
-        :rtype: int
+        Returns:
+            int:
         """
         if not self._frameSet:
             return 0
@@ -303,7 +331,8 @@ class FileSequence(object):
         """
         Returns the zfill depth (ie the number of zeroes to pad with).
 
-        :rtype: int
+        Returns:
+            int:
         """
         return self._zfill
 
@@ -313,14 +342,18 @@ class FileSequence(object):
         digits are treated as a frame number and padding is applied, all other
         values are passed though.
 
-        :Example:
-                >>> seq.frame(1)
-                /foo/bar.0001.exr
-                >>> seq.frame("#")
-                /foo/bar.#.exr
+        Examples:
+            >>> seq.frame(1)
+            /foo/bar.0001.exr
+            >>> seq.frame("#")
+            /foo/bar.#.exr
 
-        :param frame: the desired frame number (int/str) or a char to pass through (ie. #)
-        :rtype: str
+        Args:
+            frame (int or str): the desired frame number or a char to pass
+                through (ie. #)
+
+        Returns:
+            str:
         """
         try:
             zframe = str(int(frame)).zfill(self._zfill)
@@ -340,9 +373,11 @@ class FileSequence(object):
         """
         Return the path to the file at the given index.
 
-        :type idx: int
-        :param idx: the desired index
-        :rtype: str
+        Args:
+            idx (int): the desired index
+
+        Returns:
+            str:
         """
         return self.__getitem__(idx)
 
@@ -351,7 +386,8 @@ class FileSequence(object):
         Allow iteration over the path or paths this :class:`FileSequence`
         represents.
 
-        :rtype: generator
+        Yields:
+            :class:`FileSequence`:
         """
         # If there is no frame range, or there is no padding
         # characters, then we only want to represent a single path
@@ -372,9 +408,14 @@ class FileSequence(object):
         Slicing outside the range of the sequence results in an
         IndexError
 
-        :type idx: int or slice
-        :param idx: the desired index
-        :rtype: str or :obj:`FileSequence`
+        Args:
+            idx (int or slice): the desired index
+
+        Returns:
+            str or :obj:`FileSequence`:
+
+        Raises:
+            :class:`IndexError`: If slice is outside the range of the sequence
         """
         if not self._frameSet:
             return str(self)
@@ -396,7 +437,8 @@ class FileSequence(object):
         """
         The length (number of files) represented by this :class:`FileSequence`.
 
-        :rtype: int
+        Returns:
+            int:
         """
         if not self._frameSet or not self._zfill:
             return 1
@@ -406,7 +448,8 @@ class FileSequence(object):
         """
         String representation of this :class:`FileSequence`.
 
-        :rtype: str
+        Returns:
+            str:
         """
         frameSet = str(self._frameSet or "")
         return "".join((
@@ -435,8 +478,11 @@ class FileSequence(object):
         determine if the files actually exist on disk, it assumes you already
         know that.
 
-        :param paths: a list of paths
-        :rtype: generator
+        Args:
+            paths (list[str]): a list of paths
+
+        Yields:
+            :obj:`FileSequence`:
         """
         seqs = {}
         _check = DISK_RE.match
@@ -472,8 +518,11 @@ class FileSequence(object):
         to determine if the files actually exist on disk, it assumes you
         already know that.
 
-        :param paths: a list of paths
-        :rtype: list
+        Args:
+            paths (list[str]): a list of paths
+
+        Returns:
+            list:
         """
         return list(FileSequence.yield_sequences_in_list(paths))
 
@@ -481,28 +530,29 @@ class FileSequence(object):
     def findSequencesOnDisk(cls, pattern, include_hidden=False, strictPadding=False):
         """
         Yield the sequences found in the given directory.
-        
-        Example::
+
+        Examples:
             findSequencesOnDisk('/path/to/files')
 
         The pattern can also specify glob-like shell wildcards including the following:
             ?         - 1 wildcard character
             *         - 1 or more wildcard character
             {foo,bar} - either 'foo' or 'bar'
-        
+
         Exact frame ranges are not considered, and padding characters are converted to
         wildcards (# or @)
 
-        Example::
+        Examples:
             findSequencesOnDisk('/path/to/files/image_stereo_{left,right}.#.jpg')
             findSequencesOnDisk('/path/to/files/imag?_*_{left,right}.@@@.jpg', strictPadding=True)
-        
-        :param pattern: directory to scan, or pattern to filter in directory
-        :type include_hidden: bool
-        :param include_hidden: if true, show .hidden files as well
-        :type strictPadding: bool
-        :param strictPadding: if True, ignore files with padding length different from pattern
-        :rtype: list
+
+        Args:
+            pattern (str): directory to scan, or pattern to filter in directory
+            include_hidden (bool): if true, show .hidden files as well
+            strictPadding (bool): if True, ignore files with padding length different from pattern
+
+        Returns:
+            list:
         """
         # reserve some functions we're going to need quick access to
         _not_hidden = lambda f: not f.startswith('.')
@@ -566,7 +616,7 @@ class FileSequence(object):
             files = _filter_padding(files)
 
         # Ensure our dirpath ends with a path separator, so
-        # that we can control which sep is used during the 
+        # that we can control which sep is used during the
         # os.path.join
         sep = utils._getPathSep(dirpath)
         if not dirpath.endswith(sep):
@@ -582,25 +632,30 @@ class FileSequence(object):
         """
         Search for a specific sequence on disk.
 
-        The padding characters used in the pattern are used to filter the 
+        The padding characters used in the pattern are used to filter the
         frame values of the files on disk (if strictPadding is True).
 
-        :Example:
-            # Find sequence matching basename and extension, and a wildcard for
-            # any frame.
-            # returns bar.1.exr bar.10.exr, bar.100.exr, bar.1000.exr, inclusive
+        Examples:
+            Find sequence matching basename and extension, and a wildcard for
+            any frame.
+            returns bar.1.exr bar.10.exr, bar.100.exr, bar.1000.exr, inclusive
+
             >>> findSequenceOnDisk("seq/bar@@@@.exr")
 
-            # Find exactly 4-padded sequence, i.e. seq/bar1-100#.exr
-            # returns only frames bar1000.exr through bar9999.exr
+            Find exactly 4-padded sequence, i.e. seq/bar1-100#.exr
+            returns only frames bar1000.exr through bar9999.exr
+
             >>> findSequenceOnDisk("seq/bar#.exr", strictPadding=True)
 
-           
-        :param pattern: the sequence pattern being searched for
-        :rtype: str
-        :param strictPadding: if True, ignore files with padding length different from pattern
-        :rtype: bool
-        :raises: :class:`fileseq.exceptions.FileSeqException` if no sequence is found on disk
+        Args:
+            pattern (str): the sequence pattern being searched for
+            strictPadding (bool): if True, ignore files with padding length different from pattern
+
+        Returns:
+            str:
+
+        Raises:
+            :class:`fileseq.exceptions.FileSeqException`: if no sequence is found on disk
         """
         seq = cls(pattern)
 
@@ -631,6 +686,13 @@ class FileSequence(object):
         """
         Yield only path elements from iterable which have a frame
         padding that matches the given target padding number
+
+        Args:
+            iterable (collections.Iterable):
+            num (int):
+
+        Yields:
+            str:
         """
         _check = DISK_RE.match
 
@@ -642,13 +704,19 @@ class FileSequence(object):
                 actualNum = len(matches.group(3) or '')
                 if actualNum != num:
                     continue
-            
+
             yield item
 
     @staticmethod
     def getPaddingChars(num):
         """
         Given a particular amount of padding, return the proper padding characters.
+
+        Args:
+            num (int):
+
+        Returns:
+            str:
         """
         if num == 0:
             return "@"
@@ -662,10 +730,14 @@ class FileSequence(object):
         """
         Given a supported group of padding characters, return the amount of padding.
 
-        :type chars: str
-        :param chars: a supported group of padding characters
-        :rtype: int
-        :raises: ValueError if unsupported padding character is detected
+        Args:
+            chars (str): a supported group of padding characters
+
+        Returns:
+            int:
+
+        Raises:
+            ValueError: if unsupported padding character is detected
         """
         match = PRINTF_SYNTAX_PADDING_RE.match(chars)
         if match:

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -65,7 +65,7 @@ class FrameSet(Set):
             as a string (ie "1-100x5")
 
     Raises:
-        :class:`fileseq.exceptions.ParseException`: if the frame range
+        :class:`.ParseException`: if the frame range
             (or a portion of it) could not be parsed.
         :class:`fileseq.exceptions.MaxSizeException`: if the range exceeds
             `fileseq.constants.MAX_FRAME_SIZE`
@@ -81,7 +81,7 @@ class FrameSet(Set):
             frange (str or :class:`FrameSet`): the frame range as a string (ie "1-100x5")
 
         Raises:
-            :class:`fileseq.exceptions.ParseException`: if the frame range
+            :class:`.ParseException`: if the frame range
                 (or a portion of it) could not be parsed.
             :class:`fileseq.exceptions.MaxSizeException`: if the range exceeds
                 `fileseq.constants.MAX_FRAME_SIZE`
@@ -462,7 +462,7 @@ class FrameSet(Set):
 
     def __getitem__(self, index):
         """
-        Allows indexing into the ordered frames of this :class:`fileseq.frameset.FrameSet`.
+        Allows indexing into the ordered frames of this :class:`FrameSet`.
 
         Args:
             index (int): the index to retrieve
@@ -1006,7 +1006,7 @@ class FrameSet(Set):
             tuple: (start, end, modifier, chunk)
 
         Raises:
-            :class:`fileseq.exceptions.ParseException`: if the frame range can
+            :class:`.ParseException`: if the frame range can
                 not be parsed
         """
         match = FRANGE_RE.match(frange)

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -13,8 +13,9 @@ from fileseq.exceptions import MaxSizeException, ParseException
 from fileseq.utils import xfrange, unique, pad
 
 # Issue #44
-# Possibly use an alternate xrange implementation, depending on platform. 
+# Possibly use an alternate xrange implementation, depending on platform.
 from fileseq.utils import xrange
+
 
 class FrameSet(Set):
     """
@@ -43,7 +44,7 @@ class FrameSet(Set):
     Caveats:
         1. Because the internal storage of a ``FrameSet`` contains the discreet
            values of the entire range, an exception will be thrown if the range
-           exceeds a large reasonable limit, which could lead to huge memory 
+           exceeds a large reasonable limit, which could lead to huge memory
            allocations or memory failures. See `fileseq.constants.MAX_FRAME_SIZE`.
         2. All frozenset operations return a normalized :class:`FrameSet`:
            internal frames are in numerically increasing order.
@@ -58,14 +59,6 @@ class FrameSet(Set):
            as both its start and end methods will raise IndexError.  The
            :meth:`is_null`
            property has been added to allow you to guard against this.
-
-    :type frange: str
-    :param frange: the frame range as a string (ie "1-100x5")
-    :rtype: None
-    :raises: :class:`fileseq.exceptions.ParseException` if the frame range
-             (or a portion of it) could not be parsed.
-             :class:`fileseq.exceptions.MaxSizeException` if the range exceeds
-             `fileseq.constants.MAX_FRAME_SIZE`
     """
 
     __slots__ = ('_frange', '_items', '_order')
@@ -74,17 +67,31 @@ class FrameSet(Set):
         """
         Initialize the :class:`FrameSet` object.
 
-        :type frange: str
-        :param frange: the frame range as a string (ie "1-100x5")
-        :returns: the :class:`FrameSet` instance
-        :raises: :class:`fileseq.exceptions.ParseException` if the frame range
-                 (or a portion of it) could not be parsed
+        Args:
+            frange (str or FrameSet): the frame range as a string (ie "1-100x5")
+
+        Raises:
+            :class:`fileseq.exceptions.ParseException`: if the frame range
+                (or a portion of it) could not be parsed.
+            :class:`fileseq.exceptions.MaxSizeException`: if the range exceeds
+                `fileseq.constants.MAX_FRAME_SIZE`
         """
         self = super(cls, FrameSet).__new__(cls, *args, **kwargs)
         return self
 
+    def __init__(self, frange):
+        """Initialize the :class:`FrameSet` object.
 
-    def __init__(self, frange):        
+        Args:
+            frange (str or FrameSet or collections.Iterable): the frame range
+                as a string (ie "1-100x5")
+
+        Raises:
+            :class:`fileseq.exceptions.ParseException`: if the frame range
+                (or a portion of it) could not be parsed.
+            :class:`fileseq.exceptions.MaxSizeException`: if the range exceeds
+                `fileseq.constants.MAX_FRAME_SIZE`
+        """
         # if the user provides anything but a string, short-circuit the build
         if not isinstance(frange, basestring):
             # if it's apparently a FrameSet already, short-circuit the build
@@ -132,7 +139,7 @@ class FrameSet(Set):
         items = set()
         order = []
 
-        maxSize = constants.MAX_FRAME_SIZE 
+        maxSize = constants.MAX_FRAME_SIZE
 
         for part in self._frange.split(","):
             # this is to deal with leading / trailing commas
@@ -183,7 +190,8 @@ class FrameSet(Set):
         Read-only access to determine if the :class:`FrameSet` is the null or
         empty :class:`FrameSet`.
 
-        :rtype: bool
+        Returns:
+            bool:
         """
         return not (self._frange and self._items and self._order)
 
@@ -192,7 +200,8 @@ class FrameSet(Set):
         """
         Read-only access to the frame range used to create this :class:`FrameSet`.
 
-        :rtype: frozenset
+        Returns:
+            frozenset:
         """
         return self._frange
 
@@ -201,7 +210,8 @@ class FrameSet(Set):
         """
         Read-only access to the unique frames that form this :class:`FrameSet`.
 
-        :rtype: frozenset
+        Returns:
+            frozenset:
         """
         return self._items
 
@@ -210,7 +220,8 @@ class FrameSet(Set):
         """
         Read-only access to the ordered frames that form this :class:`FrameSet`.
 
-        :rtype: tuple
+        Returns:
+            tuple:
         """
         return self._order
 
@@ -219,9 +230,12 @@ class FrameSet(Set):
         """
         Build a :class:`FrameSet` from an iterable of frames.
 
-        :param frames: an iterable object containing frames as integers
-        :param sort: True to sort frames before creation, default is False
-        :rtype: :class:`FrameSet`
+        Args:
+            frames (collections.Iterable): an iterable object containing frames as integers
+            sort (bool): True to sort frames before creation, default is False
+
+        Returns:
+            :class:`FrameSet`:
         """
         return FrameSet(sorted(frames) if sort else frames)
 
@@ -230,9 +244,15 @@ class FrameSet(Set):
         """
         Private method to simplify comparison operations.
 
-        :param other: the :class:`FrameSet`, set, frozenset, or iterable to be compared
-        :rtype: :class:`FrameSet`
-        :returns: :class:`NotImplemented` if a comparison is impossible
+        Args:
+            other: the :class:`FrameSet`, set, frozenset, or iterable to be
+                compared
+
+        Returns:
+            :class:`FrameSet`
+
+        Raises:
+            :class:`NotImplemented`: if a comparison is impossible
         """
         if isinstance(other, FrameSet):
             return other
@@ -245,10 +265,14 @@ class FrameSet(Set):
         """
         Return the index of the given frame number within the :class:`FrameSet`.
 
-        :type frame: int
-        :param frame: the frame number to find the index for
-        :rtype: int
-        :raises: :class:`ValueError` if frame is not in self
+        Args:
+            frame (int): the frame number to find the index for
+
+        Returns:
+            int:
+
+        Raises:
+            :class:`ValueError`: if frame is not in self
         """
         return self.order.index(frame)
 
@@ -256,10 +280,14 @@ class FrameSet(Set):
         """
         Return the frame at the given index.
 
-        :type index: int
-        :param index: the index to find the frame for
-        :rtype: int
-        :raises: :class:`IndexError` if index is out of bounds
+        Args:
+            index (int): the index to find the frame for
+
+        Returns:
+            int:
+
+        Raises:
+            :class:`IndexError`: if index is out of bounds
         """
         return self.order[index]
 
@@ -267,9 +295,11 @@ class FrameSet(Set):
         """
         Check if the :class:`FrameSet` contains the frame.
 
-        :type frame: int
-        :param frame: the frame number to search for
-        :rtype: bool
+        Args:
+            frame (int): the frame number to search for
+
+        Returns:
+            bool:
         """
         return frame in self
 
@@ -277,8 +307,11 @@ class FrameSet(Set):
         """
         The first frame in the :class:`FrameSet`.
 
-        :rtype: int
-        :raises: :class:`IndexError` (with the empty :class:`FrameSet`)
+        Returns:
+            int:
+
+        Raises:
+            :class:`IndexError`: (with the empty :class:`FrameSet`)
         """
         return self.order[0]
 
@@ -286,8 +319,11 @@ class FrameSet(Set):
         """
         The last frame in the :class:`FrameSet`.
 
-        :rtype: int
-        :raises: :class:`IndexError` (with the empty :class:`FrameSet`)
+        Returns:
+            int:
+
+        Raises:
+            :class:`IndexError`: (with the empty :class:`FrameSet`)
         """
         return self.order[-1]
 
@@ -295,8 +331,8 @@ class FrameSet(Set):
         """
         Return whether the frame range represents consecutive integers,
         as opposed to having a stepping >= 2
-    
-        :Example:
+
+        Examples:
             >>> FrameSet('1-100').isConsecutive()
             True
             >>> FrameSet('1-100x2').isConsecutive()
@@ -304,7 +340,8 @@ class FrameSet(Set):
             >>> FrameSet('1-50,60-100').isConsecutive()
             False
 
-        :rtype: bool
+        Returns:
+            bool:
         """
         return len(self) == abs(self.end()-self.start()) + 1
 
@@ -313,15 +350,17 @@ class FrameSet(Set):
         Return the frame range used to create this :class:`FrameSet`, padded if
         desired.
 
-        :Example:
+        Examples:
             >>> FrameSet('1-100').frameRange()
             '1-100'
             >>> FrameSet('1-100').frameRange(5)
             '00001-00100'
 
-        :type zfill: int
-        :param zfill: the width to use to zero-pad the frame range string
-        :rtype: str
+        Args:
+            zfill (int): the width to use to zero-pad the frame range string
+
+        Returns:
+            str:
         """
         return FrameSet.padFrameRange(self.frange, zfill)
 
@@ -331,19 +370,23 @@ class FrameSet(Set):
         desired.
         The inverse is every frame within the full extent of the range.
 
-        :Example:
+        Examples:
             >>> FrameSet('1-100x2').invertedFrameRange()
             '2-98x2'
             >>> FrameSet('1-100x2').invertedFrameRange(5)
             '00002-00098x2'
 
-        If the inverted frame size exceeds `fileseq.constants.MAX_FRAME_SIZE`, 
+        If the inverted frame size exceeds `fileseq.constants.MAX_FRAME_SIZE`,
         a ``MaxSizeException`` will be raised.
 
-        :type zfill: int
-        :param zfill: the width to use to zero-pad the frame range string
-        :rtype: str
-        :raises: :class:`fileseq.exceptions.MaxSizeException`
+        Args:
+            zfill (int): the width to use to zero-pad the frame range string
+
+        Returns:
+            str:
+
+        Raises:
+            :class:`fileseq.exceptions.MaxSizeException`:
         """
         result = []
         frames = sorted(self.items)
@@ -352,14 +395,14 @@ class FrameSet(Set):
             if next_frame - frame != 1:
                 r = xrange(frame + 1, next_frame)
                 # Check if the next update to the result set
-                # will exceed out max frame size. 
+                # will exceed out max frame size.
                 # Prevent memory overflows.
                 self._maxSizeCheck(len(r) + len(result))
                 result += r
-        
+
         if not result:
             return ''
-        
+
         return FrameSet.framesToFrameRange(
             result, zfill=zfill, sort=False, compress=False)
 
@@ -367,7 +410,8 @@ class FrameSet(Set):
         """
         Returns a new normalized (sorted and compacted) :class:`FrameSet`.
 
-        :rtype: :class:`FrameSet`
+        Returns:
+            :class:`FrameSet`:
         """
         return FrameSet(FrameSet.framesToFrameRange(
             self.items, sort=True, compress=False))
@@ -376,7 +420,8 @@ class FrameSet(Set):
         """
         Allows for serialization to a pickled :class:`FrameSet`.
 
-        :rtype: tuple (frame range string, )
+        Returns:
+            tuple: (frame range string, )
         """
         # we have to special-case the empty FrameSet, because of a quirk in
         # Python where __setstate__ will not be called if the return value of
@@ -387,10 +432,12 @@ class FrameSet(Set):
         """
         Allows for de-serialization from a pickled :class:`FrameSet`.
 
-        :type state: tuple, str, or dict
-        :param state: A string/dict can be used for backwards compatibility
-        :rtype: None
-        :raises: :class:`ValueError` if state is not an appropriate type
+        Args:
+            state (tuple or str or dict): A string/dict can be used for
+                backwards compatibility
+
+        Raises:
+            ValueError: if state is not an appropriate type
         """
         if isinstance(state, tuple):
             # this is to allow unpickling of "3rd generation" FrameSets,
@@ -418,10 +465,14 @@ class FrameSet(Set):
         """
         Allows indexing into the ordered frames of this :class:`FrameSet`.
 
-        :type int:
-        :param index: the index to retrieve
-        :rtype: int
-        :raises: :class:`IndexError` if index is out of bounds
+        Args:
+            index (int): the index to retrieve
+
+        Returns:
+            int:
+
+        Raises:
+            :class:`IndexError`: if index is out of bounds
         """
         return self.order[index]
 
@@ -429,7 +480,8 @@ class FrameSet(Set):
         """
         Returns the length of the ordered frames of this :class:`FrameSet`.
 
-        :rtype: int
+        Returns:
+            int:
         """
         return len(self.order)
 
@@ -437,7 +489,8 @@ class FrameSet(Set):
         """
         Returns the frame range string of this :class:`FrameSet`.
 
-        :rtype: str
+        Returns:
+            str:
         """
         return self.frange
 
@@ -445,7 +498,8 @@ class FrameSet(Set):
         """
         Returns a long-form representation of this :class:`FrameSet`.
 
-        :rtype: str
+        Returns:
+            str:
         """
         return '{0}("{1}")'.format(self.__class__.__name__, self.frange)
 
@@ -453,7 +507,8 @@ class FrameSet(Set):
         """
         Allows for iteration over the ordered frames of this :class:`FrameSet`.
 
-        :rtype: generator
+        Returns:
+            generator:
         """
         return (i for i in self.order)
 
@@ -462,7 +517,8 @@ class FrameSet(Set):
         Allows for reversed iteration over the ordered frames of this
         :class:`FrameSet`.
 
-        :rtype: generator
+        Returns:
+            generator:
         """
         return (i for i in reversed(self.order))
 
@@ -470,9 +526,11 @@ class FrameSet(Set):
         """
         Check if item is a member of this :class:`FrameSet`.
 
-        :type item: int
-        :param item: the frame number to check for
-        :rtype: bool
+        Args:
+            item (int): the frame number to check for
+
+        Returns:
+            bool:
         """
         return item in self.items
 
@@ -481,7 +539,8 @@ class FrameSet(Set):
         Builds the hash of this :class:`FrameSet` for equality checking and to
         allow use as a dictionary key.
 
-        :rtype: int
+        Returns:
+            int:
         """
         return hash(self.frange) | hash(self.items) | hash(self.order)
 
@@ -491,7 +550,7 @@ class FrameSet(Set):
         a :class:`FrameSet`, but is a set, frozenset, or is iterable, it will be
         cast to a :class:`FrameSet`.
 
-        .. note::
+        Note:
 
             A :class:`FrameSet` is less than other if the set of its contents are
             less, OR if the contents are equal but the order of the items is less.
@@ -502,10 +561,12 @@ class FrameSet(Set):
                 >>> FrameSet("1-5") < FrameSet("5-1")
                 True
 
-        :type other: FrameSet
-        :param other: Can also be an object that can be cast to a :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): Can also be an object that can be cast to a :class:`FrameSet`
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -519,10 +580,12 @@ class FrameSet(Set):
         If `other` is not a :class:`FrameSet`, but is a set, frozenset, or
         is iterable, it will be cast to a :class:`FrameSet`.
 
-        :type other: FrameSet
-        :param other: Also accepts an object that can be cast to a :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): Also accepts an object that can be cast to a :class:`FrameSet`
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -536,10 +599,12 @@ class FrameSet(Set):
         If `other` is not a :class:`FrameSet`, but is a set, frozenset, or
         is iterable, it will be cast to a :class:`FrameSet`.
 
-        :type other: :class:`FrameSet`
-        :param other: Also accepts an object that can be cast to a :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): Also accepts an object that can be cast to a :class:`FrameSet`
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         if not isinstance(other, FrameSet):
             if not hasattr(other, '__iter__'):
@@ -556,10 +621,12 @@ class FrameSet(Set):
         If `other` is not a :class:`FrameSet`, but is a set, frozenset, or
         is iterable, it will be cast to a :class:`FrameSet`.
 
-        :type other: :class:`FrameSet`
-        :param other: Also accepts an object that can be cast to a :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): Also accepts an object that can be cast to a :class:`FrameSet`
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         is_equals = self == other
         if is_equals != NotImplemented:
@@ -572,10 +639,12 @@ class FrameSet(Set):
         If `other` is not a :class:`FrameSet`, but is a set, frozenset, or
         is iterable, it will be cast to a :class:`FrameSet`.
 
-        :type other: :class:`FrameSet`
-        :param other: Also accepts an object that can be cast to one a :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): Also accepts an object that can be cast to a :class:`FrameSet`
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -588,7 +657,7 @@ class FrameSet(Set):
         If `other` is not a :class:`FrameSet`, but is a set, frozenset, or
         is iterable, it will be cast to a :class:`FrameSet`.
 
-        .. note::
+        Note:
            A :class:`FrameSet` is greater than `other` if the set of its
            contents are greater,
            OR if the contents are equal but the order is greater.
@@ -599,10 +668,12 @@ class FrameSet(Set):
                >>> FrameSet("1-5") > FrameSet("5-1")
                False
 
-        :type other: :class:`FrameSet`
-        :param other: Also accepts an object that can be cast to a :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if :param: other fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): Also accepts an object that can be cast to a :class:`FrameSet`
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -616,14 +687,17 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` that holds only the
         frames `self` and `other` have in common.
 
-        .. note::
+        Note:
 
             The order of operations is irrelevant:
             ``(self & other) == (other & self)``
 
-        :type other: :class:`FrameSet`
-        :rtype: :class:`FrameSet`, or :class:`NotImplemented` if :param: other
-                fails to convert to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            :class:`FrameSet`:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -638,13 +712,16 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` that holds only the
         frames of `self` that are not in `other.`
 
-        .. note::
+        Note:
 
             This is for left-hand subtraction (``self - other``).
 
-        :type other: :class:`FrameSet`
-        :rtype: :class:`FrameSet`, or :class:`NotImplemented` if `other`
-                fails to convert to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            :class:`FrameSet`:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -657,13 +734,16 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` that holds only the
         frames of `other` that are not in `self.`
 
-        .. note::
+        Note:
 
             This is for right-hand subtraction (``other - self``).
 
-        :type other: :class:`FrameSet`
-        :rtype: :class:`FrameSet`, or :class:`NotImplemented` if `other`
-                fails to convert to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            :class:`FrameSet`:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -676,14 +756,17 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` that holds all the
         frames in `self,` `other,` or both.
 
-        .. note::
+        Note:
 
             The order of operations is irrelevant:
             ``(self | other) == (other | self)``
 
-        :type other: :class:`FrameSet`
-        :rtype: :class:`FrameSet`, or :class:`NotImplemented` if `other`
-                fails to convert to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            :class:`FrameSet`:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -698,13 +781,16 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` that holds all the
         frames in `self` or `other` but not both.
 
-        .. note::
+        Note:
             The order of operations is irrelevant:
             ``(self ^ other) == (other ^ self)``
 
-        :type other: :class:`FrameSet`
-        :rtype: :class:`FrameSet`, or :class:`NotImplemented` if `other`
-                fails to convert to a :class:`FrameSet`.
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            :class:`FrameSet`:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -718,9 +804,12 @@ class FrameSet(Set):
         Check if the contents of :class:self has no common intersection with the
         contents of :class:other.
 
-        :type other: :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -732,9 +821,12 @@ class FrameSet(Set):
         Check if the contents of `self` is a subset of the contents of
         `other.`
 
-        :type other: :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -746,9 +838,12 @@ class FrameSet(Set):
         Check if the contents of `self` is a superset of the contents of
         `other.`
 
-        :type other: :class:`FrameSet`
-        :rtype: bool, or :class:`NotImplemented` if `other` fails to convert
-                to a :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            bool:
+            :class:`NotImplemented`: if `other` fails to convert to a :class:`FrameSet`
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -760,8 +855,11 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` with the elements of `self` and
         of `other`.
 
-        :type other: :class:`FrameSet` or objects that can cast to :class:`FrameSet`
-        :rtype: :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): or objects that can cast to :class:`FrameSet`
+
+        Returns:
+            :class:`FrameSet`:
         """
         from_frozenset = self.items.union(*map(set, other))
         return self.from_iterable(from_frozenset, sort=True)
@@ -771,8 +869,11 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` with the elements common to `self` and
         `other`.
 
-        :type other: :class:`FrameSet` or objects that can cast to :class:`FrameSet`
-        :rtype: :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): or objects that can cast to :class:`FrameSet`
+
+        Returns:
+            :class:`FrameSet`:
         """
         from_frozenset = self.items.intersection(*map(set, other))
         return self.from_iterable(from_frozenset, sort=True)
@@ -782,8 +883,11 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` with elements in `self` but not in
         `other`.
 
-        :type other: :class:`FrameSet` or objects that can cast to :class:`FrameSet`
-        :rtype: :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`): or objects that can cast to :class:`FrameSet`
+
+        Returns:
+            :class:`FrameSet`:
         """
         from_frozenset = self.items.difference(*map(set, other))
         return self.from_iterable(from_frozenset, sort=True)
@@ -793,8 +897,11 @@ class FrameSet(Set):
         Returns a new :class:`FrameSet` that contains all the elements in either
         `self` or `other`, but not both.
 
-        :type other: :class:`FrameSet`
-        :rtype: :class:`FrameSet`
+        Args:
+            other (:class:`FrameSet`):
+
+        Returns:
+            :class:`FrameSet`:
         """
         other = self._cast_to_frameset(other)
         if other is NotImplemented:
@@ -806,7 +913,8 @@ class FrameSet(Set):
         """
         Returns a shallow copy of this :class:`FrameSet`.
 
-        :rtype: :class:`FrameSet`
+        Returns:
+            :class:`FrameSet`:
         """
         return FrameSet(str(self))
 
@@ -815,8 +923,11 @@ class FrameSet(Set):
         """
         Raise a MaxSizeException if ``obj`` exceeds MAX_FRAME_SIZE
 
-        :type obj: number or collection
-        :raises: :class:`fileseq.exceptions.MaxSizeException`
+        Args:
+            obj (numbers.Number or collection):
+
+        Raises:
+            :class:`fileseq.exceptions.MaxSizeException`:
         """
         fail = False
         size = 0
@@ -840,9 +951,11 @@ class FrameSet(Set):
         Return True if the given string is a frame range. Any padding
         characters, such as '#' and '@' are ignored.
 
-        :type frange: str
-        :param frange: a frame range to test
-        :rtype: bool
+        Args:
+            frange (str): a frame range to test
+
+        Returns:
+            bool:
         """
         # we're willing to trim padding characters from consideration
         # this translation is orders of magnitude faster than prior method
@@ -863,9 +976,12 @@ class FrameSet(Set):
         """
         Return the zero-padded version of the frame range string.
 
-        :type frange: str
-        :param frange: a frame range to test
-        :rtype: str
+        Args:
+            frange (str): a frame range to test
+            zfill (int):
+
+        Returns:
+            str:
         """
         def _do_pad(match):
             """
@@ -883,11 +999,16 @@ class FrameSet(Set):
         """
         Internal method: parse a discrete frame range part.
 
-        :type frange: str
-        :param frange: single part of a frame range as a string (ie "1-100x5")
-        :rtype: tuple (start, end, modifier, chunk)
-        :raises: :class:`fileseq.exceptions.ParseException` if the frame range
-                 can not be parsed
+        Args:
+            frange (str): single part of a frame range as a string
+                (ie "1-100x5")
+
+        Returns:
+            tuple: (start, end, modifier, chunk)
+
+        Raises:
+            :class:`fileseq.exceptions.ParseException`: if the frame range can
+                not be parsed
         """
         match = FRANGE_RE.match(frange)
         if not match:
@@ -914,15 +1035,14 @@ class FrameSet(Set):
         Private method: builds a proper and padded
         :class:`fileseq.framerange.FrameRange` string.
 
-        :type start: int
-        :param start: first frame
-        :type stop: int
-        :param stop: last frame
-        :type stride: int
-        :param stride: increment
-        :type zfill: int
-        :param zfill: width for zero padding
-        :rtype: str
+        Args:
+            start (int): first frame
+            stop (int or None): last frame
+            stride (int or None): increment
+            zfill (int): width for zero padding
+
+        Returns:
+            str:
         """
         if stop is None:
             return ''
@@ -941,11 +1061,12 @@ class FrameSet(Set):
         Converts a sequence of frames to a series of padded
         :class:`fileseq.framerange.FrameRange` s.
 
-        :type frames: iterable
-        :param frames: sequence of frames to process
-        :type zfill: int
-        :param zfill: width for zero padding
-        :rtype: generator
+        Args:
+            frames (collections.Iterable): sequence of frames to process
+            zfill (int): width for zero padding
+
+        Yields:
+            str:
         """
         _build = FrameSet._build_frange_part
         curr_start = None
@@ -988,15 +1109,14 @@ class FrameSet(Set):
         Converts an iterator of frames into a
         :class:`fileseq.framerange.FrameRange`.
 
-        :type frames: iterable
-        :param frames: sequence of frames to process
-        :type sort: bool
-        :param sort: sort the sequence before processing
-        :type zfill: int
-        :param zfill: width for zero padding
-        :type compress: bool
-        :param compress: remove any duplicates before processing
-        :rtype: str
+        Args:
+            frames (collections.Iterable): sequence of frames to process
+            sort (bool): sort the sequence before processing
+            zfill (int): width for zero padding
+            compress (bool): remove any duplicates before processing
+
+        Returns:
+            str:
         """
         if compress:
             frames = unique(set(), frames)

--- a/src/fileseq/frameset.py
+++ b/src/fileseq/frameset.py
@@ -42,10 +42,10 @@ class FrameSet(Set):
         >>> {FrameSet('1-20'): 'good'}
 
     Caveats:
-        1. Because the internal storage of a ``FrameSet`` contains the discreet
+        1. Because the internal storage of a :class:`FrameSet` contains the discreet
            values of the entire range, an exception will be thrown if the range
            exceeds a large reasonable limit, which could lead to huge memory
-           allocations or memory failures. See `fileseq.constants.MAX_FRAME_SIZE`.
+           allocations or memory failures. See :const:`fileseq.constants.MAX_FRAME_SIZE`.
         2. All frozenset operations return a normalized :class:`FrameSet`:
            internal frames are in numerically increasing order.
         3. Equality is based on the contents and order, NOT the frame range
@@ -59,6 +59,16 @@ class FrameSet(Set):
            as both its start and end methods will raise IndexError.  The
            :meth:`is_null`
            property has been added to allow you to guard against this.
+
+    Args:
+        frange (str or FrameSet or collections.Iterable): the frame range
+            as a string (ie "1-100x5")
+
+    Raises:
+        :class:`fileseq.exceptions.ParseException`: if the frame range
+            (or a portion of it) could not be parsed.
+        :class:`fileseq.exceptions.MaxSizeException`: if the range exceeds
+            `fileseq.constants.MAX_FRAME_SIZE`
     """
 
     __slots__ = ('_frange', '_items', '_order')
@@ -68,7 +78,7 @@ class FrameSet(Set):
         Initialize the :class:`FrameSet` object.
 
         Args:
-            frange (str or FrameSet): the frame range as a string (ie "1-100x5")
+            frange (str or :class:`FrameSet`): the frame range as a string (ie "1-100x5")
 
         Raises:
             :class:`fileseq.exceptions.ParseException`: if the frame range
@@ -81,16 +91,6 @@ class FrameSet(Set):
 
     def __init__(self, frange):
         """Initialize the :class:`FrameSet` object.
-
-        Args:
-            frange (str or FrameSet or collections.Iterable): the frame range
-                as a string (ie "1-100x5")
-
-        Raises:
-            :class:`fileseq.exceptions.ParseException`: if the frame range
-                (or a portion of it) could not be parsed.
-            :class:`fileseq.exceptions.MaxSizeException`: if the range exceeds
-                `fileseq.constants.MAX_FRAME_SIZE`
         """
         # if the user provides anything but a string, short-circuit the build
         if not isinstance(frange, basestring):
@@ -245,8 +245,7 @@ class FrameSet(Set):
         Private method to simplify comparison operations.
 
         Args:
-            other: the :class:`FrameSet`, set, frozenset, or iterable to be
-                compared
+            other (:class:`FrameSet` or set or frozenset or or iterable): item to be compared
 
         Returns:
             :class:`FrameSet`
@@ -463,7 +462,7 @@ class FrameSet(Set):
 
     def __getitem__(self, index):
         """
-        Allows indexing into the ordered frames of this :class:`FrameSet`.
+        Allows indexing into the ordered frames of this :class:`fileseq.frameset.FrameSet`.
 
         Args:
             index (int): the index to retrieve

--- a/src/fileseq/utils.py
+++ b/src/fileseq/utils.py
@@ -6,12 +6,17 @@ utils - General tools of use to fileseq operations.
 import os
 from itertools import chain, count, islice
 
-from fileseq import exceptions 
+from fileseq import exceptions
 
 
 def lenRange(start, stop, step=1):
     """
     Get the length of values for a given range
+
+    Args:
+        start (int):
+        stop (int):
+        step (int):
     """
     return (stop - start + step - 1 + 2 * (step < 0)) // step
 
@@ -19,35 +24,35 @@ def lenRange(start, stop, step=1):
 class xrange2(object):
     """
     An itertools-based replacement for xrange which does
-    not exhibit the OverflowError issue on some platforms, 
+    not exhibit the OverflowError issue on some platforms,
     when a value exceeds a C long size.
-    
+
     Provides the features of an islice, with the added support
     for checking the length of the range.
     """
-    
+
     __slots__ = ['_len', '_islice']
-    
+
     def __init__(self, start, stop=None, step=1):
         if stop is None:
             start, stop = 0, start
 
         self._len = lenRange(start, stop, step)
         self._islice = islice(count(start, step), self._len)
-    
+
     def __len__(self):
-        return self._len 
-    
+        return self._len
+
     def next(self):
         return self._islice.next()
-    
+
     def __iter__(self):
         return self._islice.__iter__()
-    
+
 
 # Issue #44
 # On Windows platform, it is possible for xrange to get an
-# OverflowError if a value passed to xrange exceeds the size of a C long. 
+# OverflowError if a value passed to xrange exceeds the size of a C long.
 # Switch to an alternate implementation.
 if os.name == 'nt':
     xrange = xrange2
@@ -61,72 +66,86 @@ def xfrange(start, stop, step=1, maxSize=-1):
     In other words it adds or subtracts a frame, as necessary, to return the
     stop value as well, if the stepped range would touch that value.
 
-    :type start: int
-    :type stop: int
-    :type step: int
-    :param step: Note that the sign will be ignored
-    :type maxSize: int
-    :param maxSize: If >= raise a :class:`fileseq.exceptions.MaxSizeException` 
-                    if size is exceeded
-    :rtype: generator
+    Args:
+        start (int):
+        stop (int):
+        step (int): Note that the sign will be ignored
+        maxSize (int):
+
+    Returns:
+        generator:
+
+    Raises:
+        :class:`fileseq.exceptions.MaxSizeException`: if size is exceeded
     """
     if start <= stop:
         stop, step = stop + 1, abs(step)
     else:
         stop, step = stop - 1, -abs(step)
-        
+
     if maxSize >= 0:
         size = lenRange(start, stop, step)
         if size > maxSize:
             raise exceptions.MaxSizeException(
                 "Size %d > %s (MAX_FRAME_SIZE)" % (size, maxSize))
-        
+
     # because an xrange is an odd object all its own, we wrap it in a
     # generator expression to get a proper Generator
     return (f for f in xrange(start, stop, step))
+
 
 def unique(seen, *iterables):
     """
     Get the unique items in iterables while preserving order.  Note that this
     mutates the seen set provided only when the returned generator is used.
 
-    :param seen: either an empty set, or the set of things already seen
-    :param iterables: one or more iterable lists to chain together
-    :rtype: generator
+    Args:
+        seen (set): either an empty set, or the set of things already seen
+        *iterables: one or more iterable lists to chain together
+
+    Returns:
+        generator:
     """
     _add = seen.add
     # return a generator of the unique items and the set of the seen items
     # the seen set will mutate when the generator is iterated over
     return (i for i in chain(*iterables) if i not in seen and not _add(i))
 
+
 def pad(number, width=0):
     """
     Return the zero-padded string of a given number.
 
-    :type number: int
-    :param number: the number to pad
-    :type width: int
-    :param width: width for zero padding
-    :rtype: str
+    Args:
+        number (int): the number to pad
+        width (int): width for zero padding
+
+    Returns:
+        str:
     """
     return str(number).zfill(width)
 
+
 def _getPathSep(path):
     """
-    Abstracts returning the appropriate path separator 
-    for the given path string. 
+    Abstracts returning the appropriate path separator
+    for the given path string.
 
     This implementation always returns ``os.sep``
 
     Abstracted to make test mocking easier.
 
-    :type path: str
-    :param path: A path to check for the most common sep
-    :rtype: str
+    Args:
+        path (str): A path to check for the most common sep
+
+    Returns:
+        str:
     """
     return os.sep
 
+
 _STR_TYPES = frozenset((unicode, str, bytes))
+
 
 def asString(obj):
     """
@@ -136,8 +155,11 @@ def asString(obj):
     If the object is unicode, return unicode.
     Otherwise return the string conversion of the object.
 
-    :type obj: Object to return as str or unicode
-    :rtype: str or unicode
+    Args:
+        obj: Object to return as str or unicode
+
+    Returns:
+        str or unicode:
     """
     if type(obj) in _STR_TYPES:
         return obj


### PR DESCRIPTION
As requested in https://github.com/sqlboy/fileseq/issues/68, docstring format is now Google one.

The current documentation config rely on restructured text. So the generated doc is not that nice. What can I do in this regard?

Unit tests pass except the ones using what seems to be an absolute path.