### PR TITLE
Support additional padding notations (printf and houdini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Support for:
 * Negative frame numbers: -10-100
 * Padding: #=4 padded, @=single pad
 * Printf Syntax Padding: %04d=4 padded, %01d=1 padded
+* Houdini Syntax Padding: $F4=4 padding, $F=1 padded
 
 ## FrameSets
 

--- a/src/fileseq/constants.py
+++ b/src/fileseq/constants.py
@@ -16,13 +16,17 @@ PAD_MAP = {"#": 4, "@": 1}
 # Example: /film/shot/renders/bilbo_bty.1-100@.exr
 # Example: /film/shot/renders/bilbo_bty.1-100@@@@#.exr
 # Example: /film/shot/renders/bilbo_bty.1-100%04d.exr
-SPLIT_PATTERN = r"((?:[-\d][-:,xy\d]*)?)([{0}]+|%\d+d)".format(''.join(PAD_MAP))
+SPLIT_PATTERN = r"((?:[-\d][-:,xy\d]*)?)([{0}]+|%(?:\d)*d|\$F(?:\d)*)".format(''.join(PAD_MAP))
 SPLIT_RE = re.compile(SPLIT_PATTERN)
 
 # Regular expression pattern for matching padding against a printf syntax
 # padding string E.g. %04d
-PRINTF_SYNTAX_PADDING_PATTERN = r"%(\d+)d"
+PRINTF_SYNTAX_PADDING_PATTERN = r"^%(\d+)*d\Z"
 PRINTF_SYNTAX_PADDING_RE = re.compile(PRINTF_SYNTAX_PADDING_PATTERN)
+
+# Regular expression pattern for matching padding against houdini syntax
+HOUDINI_SYNTAX_PADDING_PATTERN = r"\$F(\d)*\Z"
+HOUDINI_SYNTAX_PADDING_RE = re.compile(HOUDINI_SYNTAX_PADDING_PATTERN)
 
 # Regular expression pattern for matching file names on disk.
 DISK_PATTERN = r"^((?:.*[/\\])?)(.*?)(-?\d+)?((?:\.\w*[a-zA-Z]\w)*(?:\.[^.]+)?)$"

--- a/src/fileseq/filesequence.py
+++ b/src/fileseq/filesequence.py
@@ -19,7 +19,7 @@ import functools
 from glob import iglob
 
 from fileseq.exceptions import ParseException, FileSeqException
-from fileseq.constants import PAD_MAP, DISK_RE, SPLIT_RE, PRINTF_SYNTAX_PADDING_RE
+from fileseq.constants import PAD_MAP, DISK_RE, SPLIT_RE, PRINTF_SYNTAX_PADDING_RE, HOUDINI_SYNTAX_PADDING_RE
 from fileseq.frameset import FrameSet
 from fileseq import utils
 
@@ -784,9 +784,11 @@ class FileSequence(object):
         Raises:
             ValueError: if unsupported padding character is detected
         """
-        match = PRINTF_SYNTAX_PADDING_RE.match(chars)
+        match = PRINTF_SYNTAX_PADDING_RE.match(chars) or HOUDINI_SYNTAX_PADDING_RE.match(chars)
         if match:
-            return int(match.group(1))
+            paddingNumStr = match.group(1)
+            paddingNum = int(paddingNumStr) if paddingNumStr else 1
+            return max(paddingNum, 1)
 
         try:
             rval = 0


### PR DESCRIPTION
Hi!

I work at RodeoFx where we started using fileseq recently.
When testing, I realized that there was some padding notations we used that fileseq did not support. This PR add support for these cases.

Printf:
- "img.%d.exr" -> padding of 1
- "img.%0d.exr" -> padding of 1
- "img.%1d.exr" -> padding of 1

Houdini: (https://www.sidefx.com/docs/houdini/render/expressions)
- "img.$F.exr" -> padding of 1
- "img.$F1.exr" -> padding of 1
- "img.$F4.exr" -> padding of 4

I've adapted the tests in consequence, let me know if you want some things changed!

P.S.: While talking about unsupported syntax, we also support a different way of representing the frame range in the string. We call it "extended frame range" and it look like this: "img.%04d.exr 1001-1010". I think we might not be alone using that syntax, let me know if you would be interested in another PR that add support for this.